### PR TITLE
Improve documentation comments

### DIFF
--- a/service/api/auth_do_login.go
+++ b/service/api/auth_do_login.go
@@ -38,8 +38,9 @@ func toAPIUser(u models.User) apiUser {
 	}
 }
 
-// POST /session
-// Spec: login by name only; create if not exists; return 200 with {user, token} (token == userID)
+// doLogin implements POST /session.
+// It authenticates by display name only, creating the user on first login,
+// and always returns a 200 response containing {user, token} where token == userID.
 func (rt *_router) doLogin(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var req loginRequest
 	if err := readJSON(r, &req); err != nil {
@@ -56,10 +57,10 @@ func (rt *_router) doLogin(w http.ResponseWriter, r *http.Request, _ httprouter.
 		return
 	}
 
-	// exists?
-	exists, err := rt.db.CheckUserExists(name)
-	if err != nil {
-		rt.writeErrorResponse(w, http.StatusInternalServerError, "Database error")
+        // Check whether the username is already registered.
+        exists, err := rt.db.CheckUserExists(name)
+        if err != nil {
+                rt.writeErrorResponse(w, http.StatusInternalServerError, "Database error")
 		return
 	}
 

--- a/service/database/message_database_methods.go
+++ b/service/database/message_database_methods.go
@@ -27,6 +27,8 @@ func nullableReplyID(reply *string) interface{} {
 	return NullIfEmpty(strings.TrimSpace(*reply))
 }
 
+// SendPrivateMessage stores a direct message between two users.
+// It enforces that only sender_id and receiver_id are set, leaving group and conversation empty.
 func (db *appdbimpl) SendPrivateMessage(message models.Message) error {
 	_, err := db.c.Exec(`
 		INSERT INTO messages (
@@ -56,6 +58,8 @@ func (db *appdbimpl) SendPrivateMessage(message models.Message) error {
 	return err
 }
 
+// SendMessageToConversation persists a message inside a conversation thread.
+// Group messages are funneled through this path as well so ordering remains consistent.
 func (db *appdbimpl) SendMessageToConversation(message models.Message) error {
 	_, err := db.c.Exec(`
 		INSERT INTO messages (
@@ -85,6 +89,8 @@ func (db *appdbimpl) SendMessageToConversation(message models.Message) error {
 	return err
 }
 
+// SendGroupMessage guards that a conversation has been selected before delegating
+// to the shared SendMessageToConversation implementation.
 func (db *appdbimpl) SendGroupMessage(message models.Message) error {
 	if strings.TrimSpace(message.ConversationID) == "" {
 		return errors.New("conversation_id required for group message")
@@ -98,8 +104,10 @@ func (db *appdbimpl) SendGroupMessage(message models.Message) error {
 // ────────────────────────────────────────────────────────────────────────────────
 //
 
+// GetMessagesByConversation fetches messages for a conversation using optional
+// before/after cursors and a configurable limit. Results are ordered newest first.
 func (db *appdbimpl) GetMessagesByConversation(
-	convID, before, after string, limit int,
+        convID, before, after string, limit int,
 ) ([]models.Message, error) {
 
 	if limit <= 0 {
@@ -185,12 +193,15 @@ func (db *appdbimpl) GetMessagesByConversation(
 // ────────────────────────────────────────────────────────────────────────────────
 //
 
+// GetPrivateConversation reads the recent direct-message history between two users.
 func (db *appdbimpl) GetPrivateConversation(userID1, userID2 string) ([]models.Message, error) {
-	return db.getPrivateConversationEx(context.Background(), userID1, userID2, defaultPrivateLimit, "")
+        return db.getPrivateConversationEx(context.Background(), userID1, userID2, defaultPrivateLimit, "")
 }
 
+// getPrivateConversationEx is the internal worker used by GetPrivateConversation;
+// it accepts a context for future cancellation support and allows overriding the limit.
 func (db *appdbimpl) getPrivateConversationEx(
-	_ context.Context, userID1, userID2 string, limit int, _ string,
+        _ context.Context, userID1, userID2 string, limit int, _ string,
 ) ([]models.Message, error) {
 
 	rows, err := db.c.Query(`


### PR DESCRIPTION
## Summary
- refine the login handler documentation to clearly describe the authentication flow and expectations
- add detailed doc comments to message persistence and retrieval helpers for consistent, professional tone

## Testing
- go test ./... *(terminated manually due to long runtime in this environment)*
- go test ./service/... *(terminated manually due to long runtime in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940471d58788331bafc5859adffad80)