### PR TITLE
Standardize section comment headers

### DIFF
--- a/cmd/webapi/cors.go
+++ b/cmd/webapi/cors.go
@@ -1,17 +1,20 @@
+// cors.go centralizes the CORS middleware used by the web API server to make
+// cross-origin requests predictable for browsers and API clients.
 package main
 
 import (
-	"net/http"
+        "net/http"
 
-	"github.com/gorilla/handlers"
+        "github.com/gorilla/handlers"
 )
 
-// applyCORSHandler applies a CORS policy to the router. CORS stands for Cross-Origin Resource Sharing: it's a security
-// feature present in web browsers that blocks JavaScript requests going across different domains if not specified in a
-// policy. This function sends the policy of this API server.
+// applyCORSHandler wraps the given handler with the CORS policy enforced by the
+// API server. CORS (Cross-Origin Resource Sharing) is enforced by browsers to
+// control cross-domain requests, so explicitly defining the allowed headers,
+// methods, and origins keeps client behavior consistent.
 func applyCORSHandler(h http.Handler) http.Handler {
-	return handlers.CORS(
-		handlers.AllowedHeaders([]string{
+        return handlers.CORS(
+                handlers.AllowedHeaders([]string{
 			"Content-Type",
 			"Authorization",
 			"x-example-header",

--- a/cmd/webapi/load-configuration.go
+++ b/cmd/webapi/load-configuration.go
@@ -1,14 +1,17 @@
+// load-configuration.go defines the configuration structures and helpers used
+// to assemble runtime settings for the web API server from flags, environment
+// variables, and optional YAML files.
 package main
 
 import (
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"time"
+        "errors"
+        "fmt"
+        "io"
+        "os"
+        "time"
 
-	"github.com/ardanlabs/conf"
-	"gopkg.in/yaml.v2"
+        "github.com/ardanlabs/conf"
+        "gopkg.in/yaml.v2"
 )
 
 // WebAPIConfiguration describes the web API configuration. This structure is automatically parsed by

--- a/cmd/webapi/register-web-ui-stub.go
+++ b/cmd/webapi/register-web-ui-stub.go
@@ -1,12 +1,16 @@
 //go:build !webui
 
+// register-web-ui-stub.go provides a no-op placeholder when the binary is
+// compiled without the `webui` build tag, leaving routing untouched.
 package main
 
 import (
 	"net/http"
 )
 
-// registerWebUI is an empty stub because `webui` tag has not been specified.
+// registerWebUI is a stub that simply returns the provided handler when the
+// webui build tag is not enabled so the API server can run without embedded
+// frontend assets.
 func registerWebUI(hdl http.Handler) (http.Handler, error) {
-	return hdl, nil
+        return hdl, nil
 }

--- a/cmd/webapi/register-web-ui.go
+++ b/cmd/webapi/register-web-ui.go
@@ -1,5 +1,8 @@
 //go:build webui
 
+// register-web-ui.go mounts the compiled frontend assets when the binary is
+// built with the `webui` tag, while forwarding API paths to the existing API
+// handler.
 package main
 
 import (
@@ -8,10 +11,11 @@ import (
 	"github.com/GioiaZheng/Wasa_proj/webui"
 )
 
-// When built with -tags webui, mount the embedded frontend assets at "/"
-// and route all remaining paths to the API handler.
+// registerWebUI mounts the embedded frontend assets at the root path when the
+// webui build tag is enabled, while delegating API routes back to the provided
+// handler. This keeps routing concerns localized to a single place.
 func registerWebUI(api http.Handler) (http.Handler, error) {
-	mux := http.NewServeMux()
+        mux := http.NewServeMux()
 
         // Frontend entrypoint
         mux.Handle("/", webui.Handler())

--- a/service/api/api-context-wrapper.go
+++ b/service/api/api-context-wrapper.go
@@ -1,4 +1,5 @@
-// file: service/api/api-context-wrapper.go
+// api-context-wrapper.go enriches httprouter handlers with request metadata and
+// authentication details so business handlers receive consistent context.
 package api
 
 import (

--- a/service/api/api-handler.go
+++ b/service/api/api-handler.go
@@ -1,4 +1,5 @@
-// file: service/api/api-handler.go
+// api-handler.go centralizes route registration so OpenAPI endpoints stay
+// consistent and easy to audit in one place.
 package api
 
 import (

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -1,3 +1,5 @@
+// api.go constructs the HTTP router for the service API and centralizes shared
+// dependencies such as logging and database connectivity.
 package api
 
 import (

--- a/service/api/auth_do_login.go
+++ b/service/api/auth_do_login.go
@@ -1,4 +1,5 @@
-// file: service/api/auth_do_login.go
+// auth_do_login.go implements the session login endpoint and its response
+// envelope to match the OpenAPI user/token contract.
 package api
 
 import (

--- a/service/api/context-utils.go
+++ b/service/api/context-utils.go
@@ -1,4 +1,5 @@
-// file: service/api/common_io.go
+// context-utils.go centralizes JSON helpers for reading request payloads and
+// sending structured responses and errors.
 package api
 
 import (

--- a/service/api/conversation.go
+++ b/service/api/conversation.go
@@ -1,4 +1,5 @@
-// file: service/api/conversations.go
+// conversation.go implements the conversation endpoints, including validation,
+// membership checks, and responses aligned with the OpenAPI contract.
 package api
 
 import (

--- a/service/api/groups.go
+++ b/service/api/groups.go
@@ -1,3 +1,5 @@
+// groups.go contains the group management endpoints, including creation,
+// membership updates, and media uploads while enforcing OpenAPI constraints.
 package api
 
 import (
@@ -18,11 +20,9 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-//
-// -------------------------------
-// Group: Create
-// POST /groups
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group create (POST /groups)
+// -----------------------------------------------------------------------------
 
 // CreateGroupRequest matches the OpenAPI field (memberIds) and also accepts
 // a couple of legacy aliases for backward compatibility.
@@ -151,11 +151,9 @@ func (rt *_router) createGroup(
 	})
 }
 
-//
-// -------------------------------
-// Group: Get by ID / Detail
-// GET /groups/:id
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group detail (GET /groups/:id)
+// -----------------------------------------------------------------------------
 
 // getGroup returns a single group as GroupEnvelope.
 func (rt *_router) getGroup(
@@ -199,11 +197,9 @@ func (rt *_router) getGroupDetail(
 	rt.getGroup(w, r, ps, ctx)
 }
 
-//
-// -------------------------------
-// Group: List mine
-// GET /groups
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group listing (GET /groups)
+// -----------------------------------------------------------------------------
 
 // getGroupsList returns all groups of the current user as GroupEnvelopeCollection.
 func (rt *_router) getGroupsList(
@@ -233,11 +229,9 @@ func (rt *_router) getGroupsList(
 	})
 }
 
-//
-// -------------------------------
-// Group: Rename
-// PUT /groups/:id/name
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group rename (PUT /groups/:id/name)
+// -----------------------------------------------------------------------------
 
 type UpdateGroupNameRequest struct {
 	Name string `json:"name"`
@@ -289,11 +283,9 @@ func (rt *_router) setGroupName(
 	})
 }
 
-//
-// -------------------------------
-// Group: Leave (current user)
-// DELETE /groups/:id/members
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group leave (DELETE /groups/:id/members)
+// -----------------------------------------------------------------------------
 
 func (rt *_router) leaveGroup(
 	w http.ResponseWriter,
@@ -351,11 +343,9 @@ func (rt *_router) leaveGroup(
 	})
 }
 
-//
-// -------------------------------
-// Group: Add members
-// POST /groups/:id/members
-// -------------------------------
+// -----------------------------------------------------------------------------
+// Section: Group add members (POST /groups/:id/members)
+// -----------------------------------------------------------------------------
 
 type AddGroupMembersRequest struct {
 	MemberIDs       []string `json:"memberIds,omitempty"`  // OpenAPI (camelCase)
@@ -430,17 +420,13 @@ func (rt *_router) addToGroup(
 	})
 }
 
-//
-// -------------------------------
-// Group: Set/Update photo
-// PUT /groups/:id/photo
-//
+// -----------------------------------------------------------------------------
+// Section: Group photo (PUT /groups/:id/photo)
+// -----------------------------------------------------------------------------
 // Two modes:
 //   - Preset:  ?preset=avatar7   => /uploads/photos/avatar7.jpg
 //   - Upload:  multipart/form-data with file field "upload"
-//
 // Response matches FileUploadEnvelope: data.file{ filename, uri, size? }.
-// -------------------------------
 
 func (rt *_router) setGroupPhoto(
 	w http.ResponseWriter,

--- a/service/api/liveness.go
+++ b/service/api/liveness.go
@@ -1,3 +1,5 @@
+// liveness.go hosts minimal health probes used by load balancers and nginx
+// routing checks.
 package api
 
 import (

--- a/service/api/messages.go
+++ b/service/api/messages.go
@@ -1,3 +1,5 @@
+// messages.go serves message read/write endpoints and the DTO helpers that map
+// internal models to the OpenAPI JSON shapes.
 package api
 
 import (
@@ -16,11 +18,9 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  DTOs (match OpenAPI JSON shapes; keep models.* as internal)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Section: DTOs (match OpenAPI JSON shapes; keep models.* as internal)
+// -----------------------------------------------------------------------------
 
 // MessageDTO is the public JSON shape for a message (camelCase, per OpenAPI).
 type MessageDTO struct {
@@ -67,11 +67,9 @@ func messageRowToCommentDTO(m models.Message) CommentDTO {
 	}
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  Helpers
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Section: Helpers
+// -----------------------------------------------------------------------------
 
 // newMsgID generates a random message ID (TEXT).
 func newMsgID() (string, error) {
@@ -104,11 +102,9 @@ func parseLimit(raw string, dflt, min, max int) int {
 func timeBefore(a, b string) bool { return a < b }
 func timeAfter(a, b string) bool  { return a > b }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  POST /messages  -> sendMessage (OpenAPI)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Endpoint: POST /messages -> sendMessage (OpenAPI)
+// -----------------------------------------------------------------------------
 
 // sendMessageRequest matches the OpenAPI request body for sending a message.
 type sendMessageRequest struct {
@@ -181,11 +177,9 @@ func (rt *_router) sendMessage(
 	_ = writeJSON(w, http.StatusCreated, resp)
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  GET /messages  -> getConversation (OpenAPI)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Endpoint: GET /messages -> getConversation (OpenAPI)
+// -----------------------------------------------------------------------------
 
 // getMessages returns a cursor-paginated slice for a conversation.
 // Prefer database pagination; fall back to in-memory filtering to keep a 200 on failures.
@@ -280,11 +274,9 @@ func (rt *_router) getMessages(
 	_ = writeJSON(w, http.StatusOK, resp)
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  GET /messages/{id}  -> getMessageByID (OpenAPI)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Endpoint: GET /messages/{id} -> getMessageByID (OpenAPI)
+// -----------------------------------------------------------------------------
 
 func (rt *_router) getMessageByID(
 	w http.ResponseWriter,
@@ -311,11 +303,9 @@ func (rt *_router) getMessageByID(
 	_ = writeJSON(w, http.StatusOK, resp)
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  POST /messages/{id}/forward  -> forwardMessage (OpenAPI)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Endpoint: POST /messages/{id}/forward -> forwardMessage (OpenAPI)
+// -----------------------------------------------------------------------------
 
 // forwardRequest matches OpenAPI: target conversationId only.
 type forwardRequest struct {
@@ -367,14 +357,9 @@ func (rt *_router) forwardMessage(
 	_ = writeJSON(w, http.StatusOK, resp)
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  COMMENTS
-//  GET /messages/{id}/comment    -> list
-//  POST /messages/{id}/comment   -> add
-//  POST /messages/{id}/uncomment -> remove
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Section: Comments (GET, POST, POST /uncomment)
+// -----------------------------------------------------------------------------
 
 // commentAddRequest matches OpenAPI CommentMessageRequest.
 type commentAddRequest struct {
@@ -486,11 +471,9 @@ func (rt *_router) uncommentMessage(
 	_ = writeJSON(w, http.StatusOK, resp)
 }
 
-//
-// ────────────────────────────────────────────────────────────────────────────────
-//  DELETE /messages/{id}  -> deleteMessage (OpenAPI)
-// ────────────────────────────────────────────────────────────────────────────────
-//
+// -----------------------------------------------------------------------------
+// Endpoint: DELETE /messages/{id} -> deleteMessage (OpenAPI)
+// -----------------------------------------------------------------------------
 
 func (rt *_router) deleteMessage(
 	w http.ResponseWriter,

--- a/service/api/shutdown.go
+++ b/service/api/shutdown.go
@@ -1,3 +1,5 @@
+// shutdown.go provides a dev-only POST /shutdown hook so integration tests can
+// stop the server gracefully.
 //go:build dev
 
 package api

--- a/service/api/upload_utils.go
+++ b/service/api/upload_utils.go
@@ -1,3 +1,5 @@
+// upload_utils.go contains helpers for sanitizing upload paths and validating
+// basic file properties before persisting user-supplied content.
 package api
 
 import (

--- a/service/api/users.go
+++ b/service/api/users.go
@@ -1,3 +1,5 @@
+// users.go exposes user profile endpoints, covering display name updates, photo
+// uploads, user search, and profile retrieval per the OpenAPI spec.
 package api
 
 import (
@@ -12,9 +14,9 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-//
-// Helpers (request bodies)
-//
+// -----------------------------------------------------------------------------
+// Section: Helpers (request bodies)
+// -----------------------------------------------------------------------------
 
 // setUsernameBody accepts both the OpenAPI field {"name":"..."} and the legacy {"username":"..."}.
 type setUsernameBody struct {


### PR DESCRIPTION
## Summary
- standardize section header formatting across message, group, and user API files for consistent documentation
- align group photo endpoint notes with the unified comment style

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940493088f48331844ba4fba29dc008)