### PR TITLE
Refactor layout to shared flex shell

### DIFF
--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,10 +1,19 @@
 <template>
-  <div class="app-shell" :class="{ 'no-sidebar': hideSidebar }">
-    <!-- Show the sidebar only when the user is authenticated. -->
-    <Sidebar v-if="!hideSidebar" />
+  <RouterView v-slot="{ Component, route }">
+    <AppLayout v-if="!route.meta?.hideSidebar && isAuthed">
+      <div v-if="checking" class="checking">
+        <div class="spinner"></div>
+        <p>Checking session…</p>
+      </div>
 
-    <main class="flex-fill p-3">
-      <!-- Transitional notice while authentication status is being checked. -->
+      <div v-else-if="!isAuthed" class="unauth">
+        <p>You are not logged in. Redirecting to login…</p>
+      </div>
+
+      <component v-else :is="Component" />
+    </AppLayout>
+
+    <template v-else>
       <div v-if="checking" class="checking">
         <div class="spinner"></div>
         <p>Checking session…</p>
@@ -14,16 +23,15 @@
         <p>You are not logged in. Redirecting to login…</p>
       </div>
 
-      <!-- Render the active route content. -->
-      <RouterView v-else />
-    </main>
-  </div>
+      <component v-else :is="Component" />
+    </template>
+  </RouterView>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import Sidebar from '@/components/Sidebar.vue'
+import AppLayout from '@/components/AppLayout.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -75,26 +83,9 @@ watch(
   { immediate: true }
 )
 
-/* Hide the sidebar on routes that request it or when unauthenticated. */
-const hideSidebar = computed(() => !!route.meta?.hideSidebar || !isAuthed.value)
 </script>
 
 <style>
-/* Layout */
-.app-shell {
-  display: flex;
-  min-height: 100vh;
-}
-
-.app-shell main {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.no-sidebar main {
-  width: 100%;
-}
-
 /* Unauthenticated notice */
 .unauth {
   display: flex;
@@ -129,16 +120,5 @@ const hideSidebar = computed(() => !!route.meta?.hideSidebar || !isAuthed.value)
 
 @keyframes spin {
   to { transform: rotate(360deg); }
-}
-
-@media (max-width: 992px) {
-  .app-shell {
-    flex-direction: column;
-  }
-
-  .app-shell main {
-    width: 100%;
-    padding: 1rem !important;
-  }
 }
 </style>

--- a/webui/src/components/AppLayout.vue
+++ b/webui/src/components/AppLayout.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="app-layout">
+    <Sidebar class="app-layout__sidebar" />
+    <main class="app-layout__main">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '@/components/Sidebar.vue'
+</script>
+
+<style scoped>
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+  background: #f7fafc;
+}
+
+.app-layout__sidebar {
+  flex: 0 0 230px;
+  min-height: 100%;
+}
+
+.app-layout__main {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+
+@media (max-width: 992px) {
+  .app-layout {
+    flex-direction: column;
+  }
+
+  .app-layout__sidebar {
+    width: 100%;
+  }
+
+  .app-layout__main {
+    min-height: auto;
+    padding: 12px;
+  }
+}
+</style>

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -1331,7 +1331,10 @@ watch(convId, async () => {
   --avatar-bg: #e0f7ee;
   --avatar-border: #a7f3d0;
   --avatar-text: #0f766e;
-  min-height: 100vh;
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   background: #f2f5f8;
 }
 
@@ -1394,6 +1397,11 @@ watch(convId, async () => {
   max-width: 1400px;
   margin: 0 auto;
   padding: 20px 24px;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .chat-layout {
@@ -1401,6 +1409,8 @@ watch(convId, async () => {
   grid-template-columns: 360px minmax(0, 1fr);
   gap: 18px;
   align-items: start;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .chat-layout.has-group {
@@ -1416,7 +1426,8 @@ watch(convId, async () => {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: calc(100vh - 120px);
+  height: 100%;
+  min-height: 0;
 }
 
 .conv-rail__header {

--- a/webui/src/views/ContactsView.vue
+++ b/webui/src/views/ContactsView.vue
@@ -139,7 +139,10 @@ onMounted(() => {
 
 <style scoped>
 .page{
-  min-height:100vh;
+  min-height:100%;
+  height:100%;
+  display:flex;
+  flex-direction:column;
   background:
     radial-gradient(1200px 800px at 10% -10%, #f3f8ff 0, transparent 60%),
     radial-gradient(1000px 700px at 110% 0%, #eef6ff 0, transparent 55%),
@@ -169,7 +172,7 @@ onMounted(() => {
 .btn-outline{
   background:#fff; color:#334155; border:1px solid #cbd5e1; box-shadow:none;
 }
-.content{ max-width:1100px; margin:0 auto; padding:16px; }
+.content{ flex:1 1 auto; max-width:1100px; margin:0 auto; padding:16px; width:100%; }
 
 .loading{ color:#475569; display:flex; align-items:center; gap:.5rem }
 .spinner{

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -301,7 +301,10 @@ onUnmounted(() => {
 
 <style scoped>
 .page {
-  min-height: 100vh;
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   background: linear-gradient(180deg, #f1f5f9, #e2e8f0);
   color: #1f2937;
 }
@@ -324,20 +327,25 @@ onUnmounted(() => {
 }
 
 .workspace {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   padding: 14px 18px 18px;
 }
 
 .panel {
-  display: grid;
-  grid-template-columns: 340px 1fr;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
   background: #f5f7fa;
   border-radius: 18px;
-  min-height: calc(100vh - 120px);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
   overflow: hidden;
   border: 1px solid #e2e8f0;
 }
 .list-pane {
+  flex: 0 0 340px;
   background: #f7f7f7;
   border-right: 1px solid #e2e8f0;
   display: flex;
@@ -516,6 +524,8 @@ onUnmounted(() => {
   padding: 16px 0;
 }
 .conversation-pane {
+  flex: 1 1 auto;
+  min-width: 0;
   background: #ffffff;
   display: flex;
   align-items: center;
@@ -579,12 +589,13 @@ onUnmounted(() => {
     padding: 12px;
   }
   .panel {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     min-height: auto;
   }
 
 
   .list-pane {
+    flex-basis: auto;
     border-right: 0;
     border-bottom: 1px solid #e2e8f0;
   }

--- a/webui/src/views/NewGroupView.vue
+++ b/webui/src/views/NewGroupView.vue
@@ -201,7 +201,10 @@ async function create() {
 
 <style scoped>
 .page {
-  min-height: 100vh;
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   background:
     radial-gradient(1200px 800px at 10% -10%, #f3f8ff 0, transparent 60%),
     radial-gradient(1000px 700px at 110% 0%, #eef6ff 0, transparent 55%),
@@ -222,7 +225,7 @@ async function create() {
   position: absolute; left: 50%; transform: translateX(-50%);
 }
 
-.content { max-width: 900px; margin: 0 auto; padding: 18px; }
+.content { flex: 1 1 auto; max-width: 900px; margin: 0 auto; padding: 18px; width: 100%; }
 
 .form { display: flex; flex-direction: column; gap: 10px; }
 .label { font-weight: 600; color: #334155; }

--- a/webui/src/views/ProfileView.vue
+++ b/webui/src/views/ProfileView.vue
@@ -173,16 +173,21 @@ function handleError(e, fallback) {
 
 <style scoped>
 .page {
-  min-height: 100vh;
+  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   background:
     radial-gradient(1200px 800px at 10% -10%, #f3f8ff 0, transparent 60%),
     radial-gradient(1000px 700px at 110% 0%, #eef6ff 0, transparent 55%),
     linear-gradient(180deg, #ffffff, #f7fafe);
 }
 .wrap {
+  flex: 1 1 auto;
   max-width: 900px;
   margin: 0 auto;
   padding: 18px;
+  width: 100%;
 }
 .title {
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- add a shared flex-based AppLayout that anchors the sidebar and content area
- wrap authenticated routes with the layout and keep auth status messaging in the app root
- align view containers and conversation layout with flex/height rules to prevent sidebar overlap

## Testing
- yarn build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694133e366b8833189df4532fe322b70)