### PR TITLE
Refine layout to keep sidebar and views aligned

### DIFF
--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,31 +1,35 @@
 <template>
-  <RouterView v-slot="{ Component, route }">
-    <AppLayout v-if="!route.meta?.hideSidebar && isAuthed">
-      <div v-if="checking" class="checking">
-        <div class="spinner"></div>
-        <p>Checking session…</p>
-      </div>
+  <div class="app-shell">
+    <RouterView v-slot="{ Component, route }">
+      <template v-if="!route.meta?.hideSidebar && isAuthed">
+        <AppLayout>
+          <div v-if="checking" class="checking">
+            <div class="spinner"></div>
+            <p>Checking session…</p>
+          </div>
 
-      <div v-else-if="!isAuthed" class="unauth">
-        <p>You are not logged in. Redirecting to login…</p>
-      </div>
+          <div v-else-if="!isAuthed" class="unauth">
+            <p>You are not logged in. Redirecting to login…</p>
+          </div>
 
-      <component v-else :is="Component" />
-    </AppLayout>
+          <component v-else :is="Component" />
+        </AppLayout>
+      </template>
 
-    <template v-else>
-      <div v-if="checking" class="checking">
-        <div class="spinner"></div>
-        <p>Checking session…</p>
-      </div>
+      <template v-else>
+        <div v-if="checking" class="checking">
+          <div class="spinner"></div>
+          <p>Checking session…</p>
+        </div>
 
-      <div v-else-if="!isAuthed && route.path !== '/login'" class="unauth">
-        <p>You are not logged in. Redirecting to login…</p>
-      </div>
+        <div v-else-if="!isAuthed && route.path !== '/login'" class="unauth">
+          <p>You are not logged in. Redirecting to login…</p>
+        </div>
 
-      <component v-else :is="Component" />
-    </template>
-  </RouterView>
+        <component v-else :is="Component" />
+      </template>
+    </RouterView>
+  </div>
 </template>
 
 <script setup>
@@ -86,6 +90,12 @@ watch(
 </script>
 
 <style>
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 /* Unauthenticated notice */
 .unauth {
   display: flex;

--- a/webui/src/components/AppLayout.vue
+++ b/webui/src/components/AppLayout.vue
@@ -15,6 +15,7 @@ import Sidebar from '@/components/Sidebar.vue'
 .app-layout {
   display: flex;
   min-height: 100vh;
+  height: 100%;
   width: 100%;
   background: #f7fafc;
 }

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -1333,6 +1333,9 @@ watch(convId, async () => {
   --avatar-text: #0f766e;
   min-height: 100%;
   height: 100%;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   background: #f2f5f8;
@@ -1347,6 +1350,7 @@ watch(convId, async () => {
   padding: 0 16px;
   border-bottom: 1px solid #e2e8f0;
   background: #fff;
+  justify-content: flex-start;
 }
 
 .back {
@@ -1357,13 +1361,13 @@ watch(convId, async () => {
 }
 
 .title {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   font-weight: 800;
   color: #1e293b;
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: center;
 }
 
 .title-row {

--- a/webui/src/views/ContactsView.vue
+++ b/webui/src/views/ContactsView.vue
@@ -141,6 +141,9 @@ onMounted(() => {
 .page{
   min-height:100%;
   height:100%;
+  width:100%;
+  min-width:0;
+  flex:1 1 auto;
   display:flex;
   flex-direction:column;
   background:
@@ -149,13 +152,11 @@ onMounted(() => {
     linear-gradient(180deg, #ffffff, #f7fafe);
 }
 .topbar{
-  height:56px; display:flex; align-items:center; justify-content:flex-end;
+  height:56px; display:flex; align-items:center; justify-content:space-between;
   padding:0 18px; border-bottom:1px solid rgba(20,100,60,.08); background:#fff8; backdrop-filter: blur(6px);
-   position:relative;
 }
 .title{
   font-weight:800; color:#0f172a;
-  position:absolute; left:50%; transform:translateX(-50%);
 }
 
 .search{ display:flex; gap:8px; }

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -303,6 +303,9 @@ onUnmounted(() => {
 .page {
   min-height: 100%;
   height: 100%;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, #f1f5f9, #e2e8f0);

--- a/webui/src/views/NewGroupView.vue
+++ b/webui/src/views/NewGroupView.vue
@@ -203,6 +203,9 @@ async function create() {
 .page {
   min-height: 100%;
   height: 100%;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   background:
@@ -214,15 +217,13 @@ async function create() {
   height: 56px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   padding: 0 18px;
   border-bottom: 1px solid #e2e8f0;
   background: #fff;
-  position: relative;
 }
 .title {
   font-weight: 800; color: #0f172a;
-  position: absolute; left: 50%; transform: translateX(-50%);
 }
 
 .content { flex: 1 1 auto; max-width: 900px; margin: 0 auto; padding: 18px; width: 100%; }

--- a/webui/src/views/ProfileView.vue
+++ b/webui/src/views/ProfileView.vue
@@ -175,6 +175,9 @@ function handleError(e, fallback) {
 .page {
   min-height: 100%;
   height: 100%;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   background:


### PR DESCRIPTION
## Summary
- wrap authenticated routes in the shared AppLayout shell to keep sidebar and main content aligned
- give view containers consistent flex sizing and remove absolute header positioning that ignored the sidebar
- tweak layout wrapper sizing so the sidebar and routed views remain side-by-side on resize or zoom

## Testing
- yarn build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414932a98883319ff6379a8474bae2)