### PR TITLE
Normalize radii for desktop chat layout

### DIFF
--- a/webui/src/assets/main.css
+++ b/webui/src/assets/main.css
@@ -13,6 +13,10 @@
   --border: #e5e7eb;          /* Subtle borders */
   --shadow: 0 12px 32px rgba(15,23,42,.06); /* Soft shadow */
 
+  /* Radii */
+  --radius-bubble: 12px;
+  --radius-control: 8px;
+
   /* Shared gradient */
   --grad: linear-gradient(135deg,#22c55e 0%,#16a34a 45%,#3b82f6 120%);
 }
@@ -49,7 +53,7 @@ body{
   max-width: 480px;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: 0;
   box-shadow: var(--shadow);
   backdrop-filter: blur(6px);
   padding: 28px;
@@ -59,7 +63,7 @@ body{
 .page-card{
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: 0;
   box-shadow: var(--shadow);
 }
 
@@ -84,7 +88,7 @@ body{
 .input{
   width: 100%;
   height: 44px;
-  border-radius: 12px;
+  border-radius: var(--radius-control);
   border: 1px solid var(--border);
   background: #ffffff;
   color: var(--text);
@@ -102,7 +106,7 @@ body{
 .btn{
   appearance:none;
   border:0;
-  border-radius: 12px;
+  border-radius: var(--radius-control);
   background: var(--grad);
   color:#fff;
   padding: 12px 16px;

--- a/webui/src/components/AppLayout.vue
+++ b/webui/src/components/AppLayout.vue
@@ -17,7 +17,7 @@ import Sidebar from '@/components/Sidebar.vue'
   min-height: 100vh;
   height: 100%;
   width: 100%;
-  background: #f7fafc;
+  background: #e5e7eb;
 }
 
 .app-layout__sidebar {
@@ -31,7 +31,7 @@ import Sidebar from '@/components/Sidebar.vue'
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  padding: 16px;
+  padding: 0;
 }
 
 @media (max-width: 992px) {

--- a/webui/src/components/GroupEditor.vue
+++ b/webui/src/components/GroupEditor.vue
@@ -213,7 +213,7 @@ export default {
 .panel {
   width: min(680px, 92vw);
   max-height: 90vh;
-  background: #fff; border-radius: 12px;
+  background: #fff; border-radius: 0;
   box-shadow: 0 10px 28px rgba(0,0,0,0.15);
   display: grid; grid-template-rows: auto 1fr;
 }
@@ -221,19 +221,19 @@ export default {
   display: flex; justify-content: space-between; align-items: center;
   padding: 12px 14px; border-bottom: 1px solid #eee;
 }
-.close { border: 0; background: transparent; cursor: pointer; }
+.close { border: 0; background: transparent; cursor: pointer; border-radius: var(--radius-control); }
 .body { padding: 12px 14px; overflow: auto; display: grid; gap: 14px; }
 .row { display: grid; grid-template-columns: 140px 1fr; gap: 10px; align-items: center; }
 .inline { display: flex; gap: 8px; }
 .photo-actions { display: flex; align-items: center; gap: 12px; }
-.avatar { width: 64px; height: 64px; border-radius: 14px; object-fit: cover; }
+.avatar { width: 64px; height: 64px; border-radius: 50%; object-fit: cover; }
 .members { display: flex; flex-wrap: wrap; gap: 8px; }
-.member { background: #f7f7f7; padding: 4px 8px; border-radius: 8px; }
+.member { background: #f7f7f7; padding: 4px 8px; border-radius: 0; }
 .mn { font-weight: 600; margin-right: 6px; }
 .mid { font-size: 12px; opacity: .6; }
 .add { margin-top: 8px; }
 .chips { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
-.chip { background: #eef6ff; padding: 2px 6px; border-radius: 6px; font-size: 12px; }
+.chip { background: #eef6ff; padding: 2px 6px; border-radius: 0; font-size: 12px; }
 .danger { border-top: 1px dashed #eee; padding-top: 12px; margin-top: 8px; }
-.danger-btn { border: 0; background: #ffe9e9; color: #b10000; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
+.danger-btn { border: 0; background: #ffe9e9; color: #b10000; padding: 8px 10px; border-radius: var(--radius-control); cursor: pointer; }
 </style>

--- a/webui/src/components/MessageBubble.vue
+++ b/webui/src/components/MessageBubble.vue
@@ -68,7 +68,7 @@ const props = defineProps({
 .bubble {
   background: #fff;
   padding: 8px 12px;
-  border-radius: 12px;
+  border-radius: var(--radius-bubble);
   font-size: 14px;
   position: relative;
 }
@@ -85,7 +85,7 @@ const props = defineProps({
 }
 .msg-img {
   max-width: 200px;
-  border-radius: 10px;
+  border-radius: var(--radius-bubble);
 }
 .reply-preview {
   margin-top: 4px;
@@ -93,7 +93,7 @@ const props = defineProps({
   font-size: 12px;
   background: #eef2f7;
   border-left: 3px solid #3b82f6;
-  border-radius: 6px;
+  border-radius: 0;
 }
 .reactions {
   margin-top: 6px;
@@ -104,6 +104,6 @@ const props = defineProps({
   font-size: 14px;
   padding: 2px 4px;
   background: #eee;
-  border-radius: 6px;
+  border-radius: 0;
 }
 </style>

--- a/webui/src/components/Sidebar.vue
+++ b/webui/src/components/Sidebar.vue
@@ -80,7 +80,6 @@ function logout() {
   padding: 18px 14px;
   display: flex;
   flex-direction: column;
-  box-shadow: 4px 0 12px rgba(0, 0, 0, 0.03);
 }
 
 .brand {
@@ -101,7 +100,6 @@ function logout() {
   gap: 10px;
   padding: 10px 12px;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
   background: #f8fafc;
   margin-bottom: 14px;
 }
@@ -144,7 +142,6 @@ function logout() {
 .link {
   display: block;
   padding: 10px 12px;
-  border-radius: 10px;
   color: #0f172a;
   font-weight: 500;
   text-decoration: none;
@@ -167,7 +164,7 @@ function logout() {
 .logout {
   width: 100%;
   border: 0;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   padding: 8px 0;
   background: #ef4444;
   color: #fff;

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -1340,7 +1340,7 @@ watch(convId, async () => {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  background: #f2f5f8;
+  background: #e5e7eb;
 }
 
 .topbar {
@@ -1400,7 +1400,7 @@ watch(convId, async () => {
 
 .content {
   width: 100%;
-  padding: 20px 24px;
+  padding: 12px 12px 16px;
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
@@ -1408,8 +1408,6 @@ watch(convId, async () => {
 
 .content-inner {
   width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1419,23 +1417,21 @@ watch(convId, async () => {
 
 .chat-layout {
   display: grid;
-  grid-template-columns: 360px minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 12px;
+  align-items: stretch;
   flex: 1 1 auto;
   min-height: 0;
 }
 
 .chat-layout.has-group {
-  grid-template-columns: 360px minmax(0, 1fr) 340px;
+  grid-template-columns: 320px minmax(0, 1fr) 300px;
 }
 
 .conv-rail {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
+  background: #f8fafc;
+  border-right: 1px solid #d9dde3;
   padding: 14px;
-  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.06);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1463,7 +1459,7 @@ watch(convId, async () => {
 .conv-rail__badge {
   background: #e0f2fe;
   color: #0f172a;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 4px 10px;
   font-weight: 700;
 }
@@ -1471,7 +1467,7 @@ watch(convId, async () => {
 .conv-rail__search input {
   width: 100%;
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   padding: 10px 12px;
   font-size: 0.95rem;
 }
@@ -1490,7 +1486,7 @@ watch(convId, async () => {
   align-items: center;
   gap: 10px;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 12px;
   background: #f8fafc;
   cursor: pointer;
@@ -1505,7 +1501,6 @@ watch(convId, async () => {
 .conv-pill.active {
   border-color: #3b82f6;
   background: #e0f2fe;
-  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.18);
 }
 
 .conv-pill__avatar {
@@ -1567,7 +1562,7 @@ watch(convId, async () => {
   font-size: 0.85rem;
   color: #0f172a;
   background: #e2e8f0;
-  border-radius: 10px;
+  border-radius: 0;
   padding: 4px 8px;
   font-weight: 600;
 }
@@ -1578,10 +1573,9 @@ watch(convId, async () => {
 }
 
 .chat-main {
-    background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
-  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.06);
+  background: #fff;
+  border: 1px solid #d9dde3;
+  border-radius: 0;
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -1596,10 +1590,9 @@ watch(convId, async () => {
 
 .group-card {
   background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
+  border: 1px solid #d9dde3;
+  border-radius: 0;
   padding: 12px;
-  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.06);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1662,7 +1655,7 @@ watch(convId, async () => {
 .members-add {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 10px;
   display: grid;
   gap: 8px;
@@ -1697,7 +1690,7 @@ watch(convId, async () => {
   align-items: center;
   justify-content: space-between;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 8px;
   background: #f8fafc;
 }
@@ -1764,7 +1757,7 @@ watch(convId, async () => {
   background: #ecfeff;
   color: #0f766e;
   border: 1px solid #99f6e4;
-  border-radius: 10px;
+  border-radius: 0;
   padding: 8px 10px;
   margin-bottom: 8px;
 }
@@ -1773,7 +1766,7 @@ watch(convId, async () => {
   height: 65vh;
   overflow-y: auto;
   background: #f8fafc;
-  border-radius: 14px;
+  border-radius: 0;
   padding: 12px;
   border: 1px solid #e1e5eb;
 }
@@ -1839,7 +1832,7 @@ watch(convId, async () => {
   display: inline-flex;
   flex-direction: column;
   padding: 8px 12px;
-  border-radius: 14px;
+  border-radius: var(--radius-bubble);
   background: #ffffff;
   width: fit-content;
   max-width: 100%;
@@ -1865,7 +1858,7 @@ watch(convId, async () => {
   background: #eef2f7;
   font-size: 0.86rem;
   color: #334155;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -1884,7 +1877,7 @@ watch(convId, async () => {
 
 .img {
   max-width: 260px;
-  border-radius: 10px;
+  border-radius: var(--radius-bubble);
 }
 
 .meta {
@@ -1905,7 +1898,7 @@ watch(convId, async () => {
 .comment-chip {
   margin-top: 6px;
   background: #ffffff;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 4px 12px;
   font-size: 0.82rem;
   max-width: 80%;
@@ -1930,7 +1923,7 @@ watch(convId, async () => {
 }
 
 .my-reactions__pill {
-  border-radius: 999px;
+  border-radius: 0;
   background: #e0f2fe;
   border: 1px solid #bfdbfe;
   padding: 2px 8px;
@@ -1950,7 +1943,7 @@ watch(convId, async () => {
   cursor: pointer;
   font-size: 1.05rem;
   padding: 3px;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 .icon-btn:focus-visible,
@@ -1976,14 +1969,14 @@ watch(convId, async () => {
 .comment-input {
   flex: 1;
   border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   padding: 5px 8px;
 }
 
 .btn-xs {
   border: none;
   padding: 5px 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: #22c55e;
   color: white;
   cursor: pointer;
@@ -2002,7 +1995,7 @@ watch(convId, async () => {
   gap: 8px;
   padding: 10px;
   background: white;
-  border-radius: 12px;
+  border-radius: 0;
   border: 1px solid #e1e5eb;
 }
 
@@ -2015,7 +2008,7 @@ watch(convId, async () => {
 .input {
   flex: 1;
   padding: 10px;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   border: 1px solid #cbd5e1;
   resize: none;
 }
@@ -2026,7 +2019,7 @@ watch(convId, async () => {
   gap: 8px;
   background: #f1f5f9;
   border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  border-radius: 0;
   padding: 6px 8px;
   margin-bottom: 6px;
   width: 100%;
@@ -2039,7 +2032,7 @@ watch(convId, async () => {
 
 .btn {
   border: none;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   background: #22c55e;
   padding: 10px 16px;
   color: white;
@@ -2089,7 +2082,7 @@ watch(convId, async () => {
   width: min(460px, 92vw);
   max-height: 80vh;
   background: #fff;
-  border-radius: 14px;
+  border-radius: 0;
   padding: 14px;
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
   display: flex;
@@ -2106,7 +2099,7 @@ watch(convId, async () => {
 .forward-search {
   width: 100%;
   padding: 10px;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   border: 1px solid #cbd5e1;
 }
 
@@ -2124,7 +2117,7 @@ watch(convId, async () => {
   align-items: center;
   padding: 10px;
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  border-radius: 0;
   background: #f8fafc;
   cursor: pointer;
   transition: 0.2s;

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -310,7 +310,7 @@ onUnmounted(() => {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, #f1f5f9, #e2e8f0);
+  background: #e5e7eb;
   color: #1f2937;
 }
 .topbar {
@@ -336,13 +336,11 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  padding: 14px 18px 18px;
+  padding: 12px 12px 16px;
 }
 
 .content-inner {
   width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -353,17 +351,15 @@ onUnmounted(() => {
 .panel {
   flex: 1 1 auto;
   min-height: 0;
-  display: flex;
-  background: #f5f7fa;
-  border-radius: 18px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-  overflow: hidden;
-  border: 1px solid #e2e8f0;
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  background: #f8fafc;
+  border: 1px solid #d9dde3;
 }
 .list-pane {
-  flex: 0 0 340px;
+  flex: 0 0 320px;
   background: #f7f7f7;
-  border-right: 1px solid #e2e8f0;
+  border-right: 1px solid #d9dde3;
   display: flex;
   flex-direction: column;
   padding: 12px;
@@ -377,7 +373,7 @@ onUnmounted(() => {
 .search {
   width: 100%;
   border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  border-radius: var(--radius-control);
   padding: 10px 12px;
   background: #ffffff;
   font-size: 0.95rem;
@@ -421,7 +417,7 @@ onUnmounted(() => {
   display: inline-flex;
   min-width: 28px;
   height: 22px;
-  border-radius: 10px;
+  border-radius: 0;
   padding: 0 8px;
   align-items: center;
   justify-content: center;
@@ -448,7 +444,7 @@ onUnmounted(() => {
 .item {
   background: #ffffff;
   border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 10px 12px;
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -470,7 +466,7 @@ onUnmounted(() => {
 .avatar {
   width: 44px;
   height: 44px;
-  border-radius: 12px;
+  border-radius: 50%;
   object-fit: cover;
   border: 1px solid #d1d5db;
   background: #fff;
@@ -478,7 +474,7 @@ onUnmounted(() => {
 .avatar-fallback {
   width: 44px;
   height: 44px;
-  border-radius: 12px;
+  border-radius: 50%;
   background: #d9f5e8;
   color: #0f766e;
   font-weight: 700;
@@ -524,7 +520,7 @@ onUnmounted(() => {
 }
 .del {
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   padding: 0.35rem 0.7rem;
   font-size: 0.8rem;
   color: #fff;
@@ -542,11 +538,12 @@ onUnmounted(() => {
 .conversation-pane {
   flex: 1 1 auto;
   min-width: 0;
-  background: #ffffff;
+  background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 32px;
+  border-left: 1px solid #d9dde3;
 }
 
 .preview-ghost {

--- a/webui/src/views/LoginView.vue
+++ b/webui/src/views/LoginView.vue
@@ -134,7 +134,7 @@ body.theme-light-login{
   max-width: 460px;
   background: #fff;
   border: 1px solid #e2e8f0;
-  border-radius: 16px;
+  border-radius: 0;
   box-shadow: 0 20px 60px rgba(2,6,23,.08);
   padding: 28px 24px;
   color: #0f172a;

--- a/webui/src/views/ProfileView.vue
+++ b/webui/src/views/ProfileView.vue
@@ -202,7 +202,7 @@ function handleError(e, fallback) {
 .card {
   background: #fff;
   border: 1px solid #e2e8f0;
-  border-radius: 16px;
+  border-radius: 0;
   padding: 16px;
   box-shadow: 0 6px 18px rgba(2, 6, 23, 0.06);
 }
@@ -256,7 +256,7 @@ function handleError(e, fallback) {
 .summary-card {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 0;
   padding: 10px 12px;
   box-shadow: 0 6px 18px rgba(2, 6, 23, 0.04);
 }
@@ -303,7 +303,7 @@ function handleError(e, fallback) {
 .input {
   flex: 1 1 220px;
   border: 1px solid #cbd5e1;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   padding: 0.55rem 0.75rem;
   outline: none;
 }
@@ -314,7 +314,7 @@ function handleError(e, fallback) {
 
 .btn {
   border: 0;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   color: #fff;
   padding: 0.55rem 0.9rem;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- introduce shared radius variables and apply them to bubbles and controls
- flatten structural containers across chat, sidebar, and profile views for a continuous workspace
- align message and avatar rounding while removing card-like edges from secondary panels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416e6eccec8331aa3ca3ecc0e3b22c)