### PR TITLE
Ensure sidebar and main content share layout flow

### DIFF
--- a/webui/src/components/AppLayout.vue
+++ b/webui/src/components/AppLayout.vue
@@ -13,7 +13,8 @@ import Sidebar from '@/components/Sidebar.vue'
 
 <style scoped>
 .app-layout {
-  display: flex;
+  display: grid;
+  grid-template-columns: 230px 1fr;
   min-height: 100vh;
   height: 100%;
   width: 100%;
@@ -21,12 +22,11 @@ import Sidebar from '@/components/Sidebar.vue'
 }
 
 .app-layout__sidebar {
-  flex: 0 0 230px;
+  position: static;
   min-height: 100%;
 }
 
 .app-layout__main {
-  flex: 1 1 auto;
   min-width: 0;
   min-height: 100vh;
   display: flex;
@@ -36,7 +36,8 @@ import Sidebar from '@/components/Sidebar.vue'
 
 @media (max-width: 992px) {
   .app-layout {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
   }
 
   .app-layout__sidebar {

--- a/webui/src/components/Sidebar.vue
+++ b/webui/src/components/Sidebar.vue
@@ -75,6 +75,7 @@ function logout() {
   width: 230px;
   flex: 0 0 230px;
   min-height: 100vh;
+  position: static;
   background: linear-gradient(180deg, #ffffff, #f8fafc);
   border-right: 1px solid #e2e8f0;
   padding: 18px 14px;


### PR DESCRIPTION
## Summary
- update AppLayout to use a two-column grid so the sidebar and main content stay in the same layout flow
- keep the sidebar positioned statically to avoid overlaying the workspace at any viewport size

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694182857a7c8331a43c6402e78b8e5f)