### PR TITLE
Align REST paths and pagination schema

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -209,6 +209,7 @@ components:
                     $ref: '#/components/schemas/User'
                 pagination:
                   type: object
+                  nullable: true
                   description: Pagination metadata.
                   properties:
                     total:
@@ -216,7 +217,7 @@ components:
                       format: int32
                       description: Total number of available items.
                       minimum: 0
-                      maximum: 1000000 
+                      maximum: 1000000
                     limit:
                       type: integer
                       format: int32
@@ -228,7 +229,7 @@ components:
                       format: int32
                       description: Zero-based index of the first returned item.
                       minimum: 0
-                      maximum: 1000000 
+                      maximum: 1000000
 
     Conversation:
       type: object
@@ -326,28 +327,27 @@ components:
                     $ref: '#/components/schemas/Conversation'
                 pagination:
                   description: Pagination metadata. May be null if pagination is not applicable.
-                  oneOf:
-                    - type: object
-                      properties:
-                        total:
-                          type: integer
-                          format: int32
-                          description: Total number of available items.
-                          minimum: 0
-                          maximum: 1000000
-                        limit:
-                          type: integer
-                          format: int32
-                          description: Page size.
-                          minimum: 1
-                          maximum: 100
-                        offset:
-                          type: integer
-                          format: int32
-                          description: Zero-based index of the first returned item.
-                          minimum: 0
-                          maximum: 1000000
-                    - type: "null"
+                  type: object
+                  nullable: true
+                  properties:
+                    total:
+                      type: integer
+                      format: int32
+                      description: Total number of available items.
+                      minimum: 0
+                      maximum: 1000000
+                    limit:
+                      type: integer
+                      format: int32
+                      description: Page size.
+                      minimum: 1
+                      maximum: 100
+                    offset:
+                      type: integer
+                      format: int32
+                      description: Zero-based index of the first returned item.
+                      minimum: 0
+                      maximum: 1000000
 
     FileUpload:
       type: object
@@ -484,6 +484,7 @@ components:
           description: Opaque cursor to fetch newer messages (for pull-to-refresh).
         pagination:
           type: object
+          nullable: true
           deprecated: true
           description: Pagination metadata (deprecated, use cursor-based instead).
           properties:
@@ -514,7 +515,10 @@ components:
           required: [data]
           properties:
             data:
-              $ref: '#/components/schemas/MessageCollection'
+              type: object
+              description: Paginated message collection payload.
+              allOf:
+                - $ref: '#/components/schemas/MessageCollection'
 
     MessageResourceEnvelope:
       description: Envelope with a single message resource.
@@ -687,6 +691,7 @@ components:
                     $ref: '#/components/schemas/Group'
                 pagination:
                   type: object
+                  nullable: true
                   description: Pagination metadata.
                   properties:
                     total:
@@ -953,7 +958,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /users/set_username:
+  /users/me/name:
     put:
       tags: [users]
       operationId: setMyUserName
@@ -986,7 +991,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /users/set_photo:
+  /users/me/photo:
     put:
       tags: [users]
       operationId: setMyPhoto
@@ -1077,7 +1082,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /users/profile/{userId}:
+  /users/{userId}/profile:
     parameters:
       - $ref: '#/components/parameters/userId'
     get:
@@ -1556,7 +1561,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /messages/{id}/forward:
+  /messages/{id}/forwards:
     parameters:
       - $ref: '#/components/parameters/id'
     post:
@@ -1636,9 +1641,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-  
-  /messages/{id}/uncomment:
-    post:
+    delete:
       tags:
       - messages
       operationId: uncommentMessage
@@ -1646,8 +1649,6 @@ paths:
       description: Delete a comment from a message
       security:
       - BearerAuth: []
-      parameters:
-      - $ref: '#/components/parameters/id'
       responses:
         '200':
           description: Comment removed successfully


### PR DESCRIPTION
## Summary
- convert procedure-style endpoints to RESTful resource paths while preserving operationIds
- align all pagination properties to nullable object definitions for consistent OpenAPI typing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694324e054d08331b7cb93faf6641ae8)