### PR TITLE
Fix conversation preview consistency

### DIFF
--- a/service/database/conversation_start.go
+++ b/service/database/conversation_start.go
@@ -181,12 +181,12 @@ func (db *appdbimpl) buildConversationFromID(cid string, requesterID string) (mo
 	var msgCreatedStr string
 
 	err = db.c.QueryRow(`
-		SELECT id, content, sender_id, conversation_id, created_at
+		SELECT id, content, sender_id, conversation_id, created_at, type
 		FROM messages
 		WHERE conversation_id = ?
 		ORDER BY created_at DESC
 		LIMIT 1
-	`, cid).Scan(&msg.ID, &msg.Content, &msg.SenderID, &msg.ConversationID, &msgCreatedStr)
+	`, cid).Scan(&msg.ID, &msg.Content, &msg.SenderID, &msg.ConversationID, &msgCreatedStr, &msg.Type)
 
 	var lastMessage *models.Message
 	var updatedAt time.Time

--- a/service/models/models.go
+++ b/service/models/models.go
@@ -31,24 +31,24 @@ type GroupMember struct {
 // Message is the internal representation used for both conversation messages
 // and comment rows while hiding routing-only fields from the public surface.
 type Message struct {
-	ID             string `db:"id"`
-	Content        string `db:"content"`
-	FileURL        string `db:"file_url"`
-	SenderID       string `db:"sender_id"`
-	ConversationID string `db:"conversation_id"`
-	CreatedAt      string `db:"created_at"`
+	ID             string `db:"id" json:"id"`
+	Content        string `db:"content" json:"content,omitempty"`
+	FileURL        string `db:"file_url" json:"fileUrl,omitempty"`
+	SenderID       string `db:"sender_id" json:"senderId,omitempty"`
+	ConversationID string `db:"conversation_id" json:"conversationId,omitempty"`
+	CreatedAt      string `db:"created_at" json:"createdAt,omitempty"`
 
 	// Type contains the message classification (text, image, or file).
-	Type   string `db:"type"`
-	Status string `db:"status"`
-	Read   bool   `db:"read"`
+	Type   string `db:"type" json:"type,omitempty"`
+	Status string `db:"status" json:"status,omitempty"`
+	Read   bool   `db:"read" json:"read,omitempty"`
 
 	// ReplyToID links to another message when the current one is a reply.
-	ReplyToID *string `db:"reply_to_id"`
+	ReplyToID *string `db:"reply_to_id" json:"replyToId,omitempty"`
 
 	// ReceiverID and GroupID are internal routing hints and are not exposed.
-	ReceiverID string `db:"receiver_id"`
-	GroupID    string `db:"group_id"`
+	ReceiverID string `db:"receiver_id" json:"-"`
+	GroupID    string `db:"group_id" json:"-"`
 }
 
 // Conversation follows the OpenAPI contract and bundles participants and

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -311,7 +311,7 @@
 
                   <div v-else class="empty-thread" role="status">
                     <p class="muted">
-                      {{ isGroup ? 'Say hello 👋 (only group members can see your messages)' : 'Say hello 👋 to start the chat.' }}
+                      {{ isGroup ? 'Start the conversation (only group members can see your messages).' : 'Start the conversation to send a message.' }}
                     </p>
                   </div>
                 </div>
@@ -750,28 +750,10 @@ function formatPreviewText(value = '') {
 function previewForMessage(raw = {}) {
   if (raw?.deleted || raw?.isDeleted) return '[Deleted]'
 
-  const type = String(raw?.type || '').toLowerCase()
-  if (type === 'image' || raw?.imageUrl || raw?.image_url) return '📷 Photo'
-  if (
-    type === 'reaction' ||
-    type === 'emoji' ||
-    raw?.reaction ||
-    raw?.reactionType ||
-    raw?.reaction_type ||
-    raw?.emoji
-  ) {
-    return '😃 Emoji'
-  }
+  const type = String(raw?.type || raw?.Type || '').toLowerCase()
+  if (type === 'image') return '📷 Photo'
 
-  const content =
-    raw?.content ||
-    raw?.text ||
-    raw?.body ||
-    raw?.message ||
-    raw?.Content ||
-    raw?.Text ||
-    raw?.Body ||
-    ''
+  const content = raw?.content ?? raw?.Content ?? ''
 
   return formatPreviewText(content)
 }
@@ -779,13 +761,7 @@ function previewForMessage(raw = {}) {
 function conversationPreviewForMessage(raw = {}, conv = null) {
   const base = previewForMessage(raw)
   if (!base) return ''
-  const isGroupType =
-    conv?.type === 'group' ||
-    !!(conv?.groupId || conv?.group_id || conv?.group?.id)
-  if (!isGroupType) return base
-  const sender = senderProfileFromRaw(raw)
-  const senderName = preferredDisplayName(sender || {}) || sender?.name || sender?.username || ''
-  return `${senderName || 'Someone'}: ${base}`
+  return base
 }
 
 function normalizeConversationList(items = []) {
@@ -794,19 +770,9 @@ function normalizeConversationList(items = []) {
 
     const fromKnownFields =
       c.lastMessage ||
-      c.last_message ||
-      c.last ||
-      c.lastmessage ||
-      c.lastMsg ||
-      c.last_msg ||
-      (Array.isArray(c.messages) ? c.messages[c.messages.length - 1] : null)
+      c.last_message
 
-    if (fromKnownFields) return fromKnownFields
-
-    if (typeof c.lastMessageContent === 'string') return { content: c.lastMessageContent }
-    if (typeof c.last_message_content === 'string') return { content: c.last_message_content }
-
-    return null
+    return fromKnownFields || null
   }
 
   return (items || [])
@@ -839,7 +805,7 @@ function normalizeConversationList(items = []) {
         ...c,
         type: isGroupType ? 'group' : c?.type,
         participants: normalizeParticipantList(c.participants || c.members || []),
-        last_preview: previewContent || (isGroupType ? 'Say hello 👋' : 'No messages yet'),
+        last_preview: previewContent || 'No messages yet',
         last_time: time,
       }
     })

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -168,77 +168,18 @@ function formatPreviewText(value = '') {
 function previewForMessage(raw = {}) {
   if (raw?.deleted || raw?.isDeleted) return '[Deleted]'
 
-  const type = String(raw?.type || '').toLowerCase()
-  if (type === 'image' || raw?.imageUrl || raw?.image_url) return '📷 Photo'
-  if (
-    type === 'reaction' ||
-    type === 'emoji' ||
-    raw?.reaction ||
-    raw?.reactionType ||
-    raw?.reaction_type ||
-    raw?.emoji
-  ) {
-    return '😃 Emoji'
-  }
+  const type = String(raw?.type || raw?.Type || '').toLowerCase()
+  if (type === 'image') return '📷 Photo'
 
-  const content =
-    raw?.content ||
-    raw?.text ||
-    raw?.body ||
-    raw?.message ||
-    raw?.Content ||
-    raw?.Text ||
-    raw?.Body ||
-    ''
+  const content = raw?.content ?? raw?.Content ?? ''
 
   return formatPreviewText(content)
-}
-
-function senderProfileFromRaw(raw = {}) {
-  const senderRaw =
-    raw.sender || raw.user || raw.author || raw.from || raw.owner || raw.created_by || raw.createdBy || {}
-
-  const senderIdValue =
-    raw.senderId || raw.sender_id || raw.userId || senderRaw.id || senderRaw.userId || senderRaw.user_id
-
-  const senderName =
-    senderRaw.name ||
-    senderRaw.username ||
-    senderRaw.displayName ||
-    senderRaw.display_name ||
-    senderRaw.fullName ||
-    senderRaw.full_name ||
-    raw.senderName ||
-    raw.sender_name ||
-    ''
-
-  const normalized = normalizeUser({
-    ...senderRaw,
-    id: senderIdValue ?? senderRaw.id,
-    name: senderName,
-  })
-
-  const senderId = normalized.id ? String(normalized.id) : ''
-
-  return senderId
-    ? {
-        id: senderId,
-        name: normalized.name || normalized.username || senderName,
-        username: normalized.username,
-      }
-    : { id: '', name: normalized.name || senderName }
 }
 
 function conversationPreviewForMessage(raw = {}, conv = null) {
   const base = previewForMessage(raw)
   if (!base) return ''
-  const isGroupType =
-    conv?.type === 'group' ||
-    !!(conv?.groupId || conv?.group_id || conv?.group?.id)
-  if (!isGroupType) return base
-  const sender = senderProfileFromRaw(raw)
-  const senderName = preferredDisplayName(sender || {}) || sender?.name || sender?.username || ''
-  return `${senderName || 'Someone'}: ${base}`
+  return base
 }
 
 // Helper to read the current user identifier as a string.
@@ -321,19 +262,9 @@ async function load() {
 
       const fromKnownFields =
         c.lastMessage ||
-        c.last_message ||
-        c.last ||
-        c.lastmessage ||
-        c.lastMsg ||
-        c.last_msg ||
-        (Array.isArray(c.messages) ? c.messages[c.messages.length - 1] : null)
+        c.last_message
 
-      if (fromKnownFields) return fromKnownFields
-
-      if (typeof c.lastMessageContent === 'string') return { content: c.lastMessageContent }
-      if (typeof c.last_message_content === 'string') return { content: c.last_message_content }
-
-      return null
+      return fromKnownFields || null
     }
 
     convs.value = (items || [])
@@ -358,7 +289,7 @@ async function load() {
           ...c,
           type: isGroupType ? 'group' : c?.type,
           participants: (c.participants || []).map(normalizeUser),
-          last_preview: previewContent || (isGroupType ? 'Say hello 👋' : 'No messages yet'),
+          last_preview: previewContent || 'No messages yet',
           last_time: time,
         }
       })


### PR DESCRIPTION
### Motivation
- Ensure conversation preview text is accurate and deterministic by using the actual last message stored by the backend instead of heuristics or hardcoded placeholders.
- Surface the last message `type` and canonical fields from the database so the UI can render previews reliably (text vs image).
- Remove the UX copy that encouraged guessing preview content (`Say hello`) and avoid the UI inventing message text.

### Description
- Database: include the `type` column in the query that loads the most recent message in `buildConversationFromID` and scan it into `msg.Type` so `LastMessage` includes message `type` (`service/database/conversation_start.go`).
- Models: add JSON tags to `Message` fields and expose the canonical names used by the API (`content`, `type`, `fileUrl`, etc.) while keeping routing hints private (`service/models/models.go`).
- Frontend: normalize conversation preview generation to read the backend `lastMessage`/`last_message` payload only, treat `type === 'image'` as `📷 Photo`, show truncated text for text messages, and fallback to `No messages yet` instead of `Say hello` (`webui/src/views/ConversationsView.vue`, `webui/src/views/ChatView.vue`).
- Frontend: remove group-sender prefixing and several heuristic field lookups so the UI no longer guesses message content from non-canonical fields or synthesizes previews.

### Testing
- No automated tests were run for this change.
- Files were staged and committed locally (`git commit`) to capture the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616eab7e888331989ddcaf74ed39b3)