### PR TITLE
Update conversation sidebar on new messages

### DIFF
--- a/webui/src/components/ConversationList.vue
+++ b/webui/src/components/ConversationList.vue
@@ -1,0 +1,364 @@
+<template>
+  <aside :class="paneClass">
+    <div class="list-header">
+      <div class="list-title">{{ title }}</div>
+      <span class="badge">{{ totalCount }}</span>
+    </div>
+
+    <div class="list-search">
+      <input
+        :value="search"
+        type="search"
+        class="search"
+        :placeholder="searchPlaceholder"
+        aria-label="Search conversations"
+        @input="onSearchInput"
+      />
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <h3 class="section-title text-secondary">Direct</h3>
+        <span class="badge">{{ privateConvs.length }}</span>
+      </div>
+
+      <ul class="list" role="list">
+        <li
+          v-for="c in privateConvs"
+          :key="c.id"
+          class="item"
+          :class="{ active: isActive(c) }"
+          @click="emitSelect(c)"
+        >
+          <div class="left">
+            <span v-if="!avatarFor(c)" class="avatar-fallback avatar-circle">{{ initials(c) }}</span>
+            <img v-else class="avatar avatar-circle" :src="avatarFor(c)" alt="avatar" />
+          </div>
+
+          <div class="info">
+            <div class="top">
+              <div class="name">{{ displayName(c) }}</div>
+              <div class="time">{{ fmtTime(c.last_time) }}</div>
+            </div>
+            <div class="bottom">
+              <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
+            </div>
+          </div>
+
+          <button v-if="showDelete" class="del" @click.stop="emitDelete(c)">Delete</button>
+        </li>
+
+        <li v-if="!privateConvs.length" class="empty">{{ emptyDirectText }}</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <div class="section-head second">
+        <h3 class="section-title text-secondary">Groups</h3>
+        <span class="badge badge--secondary">{{ groupConvs.length }}</span>
+      </div>
+
+      <ul class="list" role="list">
+        <li
+          v-for="c in groupConvs"
+          :key="c.id"
+          class="item"
+          :class="{ active: isActive(c) }"
+          @click="emitSelect(c)"
+        >
+          <div class="left">
+            <span v-if="!avatarFor(c)" class="avatar-fallback avatar-circle">{{ initials(c) }}</span>
+            <img v-else class="avatar avatar-circle" :src="avatarFor(c)" alt="avatar" />
+          </div>
+          <div class="info">
+            <div class="top">
+              <div class="name">{{ displayName(c) }}</div>
+              <div class="time">{{ fmtTime(c.last_time) }}</div>
+            </div>
+            <div class="bottom">
+              <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
+            </div>
+          </div>
+          <button v-if="showDelete" class="del" @click.stop="emitDelete(c)">Delete</button>
+        </li>
+        <li v-if="!groupConvs.length" class="empty">{{ emptyGroupText }}</li>
+      </ul>
+    </div>
+
+    <p v-if="loading" class="muted">Loading conversations…</p>
+    <ErrorMsg v-else-if="error" :text="error" />
+  </aside>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import ErrorMsg from '@/components/ErrorMsg.vue'
+
+const props = defineProps({
+  title: { type: String, default: 'Conversations' },
+  variant: { type: String, default: 'default' },
+  search: { type: String, default: '' },
+  searchPlaceholder: { type: String, default: 'search conversations' },
+  privateConvs: { type: Array, default: () => [] },
+  groupConvs: { type: Array, default: () => [] },
+  selectedId: { type: String, default: '' },
+  displayName: { type: Function, required: true },
+  avatarFor: { type: Function, required: true },
+  initials: { type: Function, required: true },
+  fmtTime: { type: Function, required: true },
+  showDelete: { type: Boolean, default: false },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+  emptyDirectText: { type: String, default: 'No direct chats yet.' },
+  emptyGroupText: { type: String, default: 'No group chats yet.' },
+})
+
+const emit = defineEmits(['update:search', 'select', 'delete'])
+
+const totalCount = computed(() => props.privateConvs.length + props.groupConvs.length)
+const paneClass = computed(() => [
+  'list-pane',
+  props.variant === 'split' ? 'list-pane--split' : '',
+])
+
+function onSearchInput(event) {
+  emit('update:search', event.target.value)
+}
+
+function normalizeId(c) {
+  return String(c?.id || '')
+}
+
+function isActive(c) {
+  return normalizeId(c) === String(props.selectedId || '')
+}
+
+function emitSelect(c) {
+  emit('select', c)
+}
+
+function emitDelete(c) {
+  emit('delete', c)
+}
+</script>
+
+<style scoped>
+.list-pane {
+  flex: 0 0 320px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  gap: 10px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.list-pane--split {
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 4px 0 2px;
+}
+
+.list-title {
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.list-search {
+  padding: 0 0 8px;
+}
+
+.search {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius-control);
+  padding: 10px 12px;
+  background: #ffffff;
+  font-size: var(--font-primary);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search:focus {
+  outline: none;
+  border-color: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 4px 4px 2px;
+}
+
+.section-head.second {
+  margin-top: 4px;
+  border-top: 1px solid #e5e7eb;
+  padding-top: 10px;
+}
+
+.section-title {
+  margin: 0;
+  font-weight: 700;
+  color: #0f172a;
+  font-size: var(--font-secondary);
+}
+
+.badge {
+  display: inline-flex;
+  min-width: 28px;
+  height: 22px;
+  border-radius: 0;
+  padding: 0 8px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  font-size: var(--font-secondary);
+  color: #475569;
+  font-weight: 600;
+}
+
+.badge--secondary {
+  background: #f1f5f9;
+  border-color: #d8e0e8;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  max-height: 100%;
+  min-height: 0;
+}
+
+.item {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  padding: 14px 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  position: relative;
+  cursor: pointer;
+}
+
+.item:hover {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.35);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+}
+
+.item.active {
+  background: #dcfce7;
+  border-color: #22c55e;
+}
+
+.item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 10px;
+  bottom: 10px;
+  width: 3px;
+  background: #22c55e;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.top {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.name {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: var(--font-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.time {
+  font-size: 0.92rem;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+.preview {
+  color: #64748b;
+  font-size: 0.92rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.del {
+  border: 0;
+  border-radius: var(--radius-control);
+  padding: 0.35rem 0.7rem;
+  font-size: var(--font-secondary);
+  color: #fff;
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  transition: 0.2s;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.item:hover .del,
+.item:focus-within .del {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.del:hover {
+  opacity: 0.9;
+}
+
+.empty {
+  text-align: center;
+  color: #6b7280;
+  padding: 16px 0;
+}
+</style>

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -13,101 +13,19 @@
         <div class="chat-layout" :class="{ 'has-group': isGroup }">
 
           <!-- ===== LEFT: CONVERSATION LIST ===== -->
-          <aside class="list-pane">
-            <div class="list-header">
-              <div class="list-title">Conversations</div>
-              <span class="badge">{{ filteredConversations.length }}</span>
-            </div>
-
-            <div class="list-search">
-              <input
-                v-model.trim="convSearch"
-                type="search"
-                class="search"
-                placeholder="search conversations"
-                aria-label="Search conversations"
-              />
-            </div>
-
-            <div class="section">
-              <div class="section-head">
-                <h3 class="section-title text-secondary">Direct</h3>
-                <span class="badge">{{ privateConvs.length }}</span>
-              </div>
-
-              <ul class="list" role="list">
-                <li
-                  v-for="c in privateConvs"
-                  :key="c.id"
-                  class="item"
-                  :class="{ active: String(c.id) === convId }"
-                  @click="selectConversation(c)"
-                >
-                  <div class="left">
-                    <span v-if="!avatarForConversation(c, meId)" class="avatar-fallback avatar-circle">{{ conversationInitial(c) }}</span>
-                    <img
-                      v-else
-                      class="avatar avatar-circle"
-                      :src="avatarForConversation(c, meId)"
-                      alt="avatar"
-                    />
-                  </div>
-
-                  <div class="info">
-                    <div class="top">
-                      <div class="name">{{ titleForConversation(c, meId) }}</div>
-                      <div class="time">{{ convTime(c.last_time) }}</div>
-                    </div>
-                    <div class="bottom">
-                      <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
-                    </div>
-                  </div>
-                </li>
-
-                <li v-if="!privateConvs.length && !convLoading && !convErr" class="empty">No direct chats yet.</li>
-              </ul>
-            </div>
-
-            <div class="section">
-              <div class="section-head second">
-                <h3 class="section-title text-secondary">Groups</h3>
-                <span class="badge badge--secondary">{{ groupConvs.length }}</span>
-              </div>
-
-              <ul class="list" role="list">
-                <li
-                  v-for="c in groupConvs"
-                  :key="c.id"
-                  class="item"
-                  :class="{ active: String(c.id) === convId }"
-                  @click="selectConversation(c)"
-                >
-                  <div class="left">
-                    <span v-if="!avatarForConversation(c, meId)" class="avatar-fallback avatar-circle">{{ conversationInitial(c) }}</span>
-                    <img
-                      v-else
-                      class="avatar avatar-circle"
-                      :src="avatarForConversation(c, meId)"
-                      alt="avatar"
-                    />
-                  </div>
-                  <div class="info">
-                    <div class="top">
-                      <div class="name">{{ titleForConversation(c, meId) }}</div>
-                      <div class="time">{{ convTime(c.last_time) }}</div>
-                    </div>
-                    <div class="bottom">
-                      <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
-                    </div>
-                  </div>
-                </li>
-                <li v-if="!groupConvs.length && !convLoading && !convErr" class="empty">No group chats yet.</li>
-              </ul>
-            </div>
-
-            <p v-if="convLoading" class="muted">Loading conversations…</p>
-            <ErrorMsg v-else-if="convErr" :text="convErr" />
-          </aside>
+          <ConversationList
+            v-model:search="convSearch"
+            :private-convs="privateConvs"
+            :group-convs="groupConvs"
+            :selected-id="convId"
+            :display-name="c => titleForConversation(c, meId)"
+            :avatar-for="c => avatarForConversation(c, meId)"
+            :initials="conversationInitial"
+            :fmt-time="convTime"
+            :loading="convLoading"
+            :error="convErr"
+            @select="selectConversation"
+          />
 
           <!-- ===== CENTER: CHAT ===== -->
           <section class="chat-pane">
@@ -570,6 +488,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ErrorMsg from '@/components/ErrorMsg.vue'
+import ConversationList from '@/components/ConversationList.vue'
 import UserSearch from '@/components/UserSearch.vue'
 import {
   getMyConversations,
@@ -751,7 +670,11 @@ function previewForMessage(raw = {}) {
   if (raw?.deleted || raw?.isDeleted) return '[Deleted]'
 
   const type = String(raw?.type || raw?.Type || '').toLowerCase()
-  if (type === 'image') return '📷 Photo'
+  if (type === 'image') return '[image]'
+  if (type === 'file') return '[file]'
+
+  const fileUrl = raw?.fileUrl ?? raw?.file_url ?? raw?.FileUrl
+  if (fileUrl) return '[file]'
 
   const content = raw?.content ?? raw?.Content ?? ''
 
@@ -764,15 +687,66 @@ function conversationPreviewForMessage(raw = {}, conv = null) {
   return base
 }
 
+function previewForNormalizedMessage(message) {
+  if (!message) return ''
+  if (message.type === 'image') return '[image]'
+  if (message.type === 'file') return '[file]'
+  return formatPreviewText(message.content)
+}
+
+function messageTime(raw = {}) {
+  return (
+    raw?.createdAt ||
+    raw?.created_at ||
+    raw?.CreatedAt ||
+    raw?.timestamp ||
+    raw?.Timestamp ||
+    null
+  )
+}
+
+function messageTimeValue(raw = {}) {
+  const value = messageTime(raw)
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.getTime()
+}
+
 function normalizeConversationList(items = []) {
   const pickLastMessage = (c) => {
     if (!c) return null
 
-    const fromKnownFields =
-      c.lastMessage ||
-      c.last_message
+    const fromKnownFields = c.lastMessage || c.last_message
+    if (fromKnownFields) return fromKnownFields
 
-    return fromKnownFields || null
+    const list =
+      c.messages ||
+      c.Messages ||
+      c.messageList ||
+      c.message_list ||
+      c.items ||
+      c.list
+
+    if (!Array.isArray(list) || !list.length) return null
+
+    let best = null
+    let bestTime = null
+    list.forEach((msg) => {
+      const ts = messageTimeValue(msg)
+      if (ts !== null) {
+        if (bestTime === null || ts > bestTime) {
+          bestTime = ts
+          best = msg
+        }
+        return
+      }
+      if (!best) {
+        best = msg
+      }
+    })
+
+    return best || list[list.length - 1]
   }
 
   return (items || [])
@@ -787,19 +761,7 @@ function normalizeConversationList(items = []) {
         type: isGroupType ? 'group' : c?.type,
       })
 
-      const time =
-        last.createdAt ||
-        last.created_at ||
-        last.CreatedAt ||
-        last.timestamp ||
-        last.Timestamp ||
-        c.updatedAt ||
-        c.updated_at ||
-        c.UpdatedAt ||
-        c.createdAt ||
-        c.created_at ||
-        c.CreatedAt ||
-        null
+      const time = messageTime(last)
 
       return {
         ...c,
@@ -1300,12 +1262,21 @@ function normalizeMessage(raw) {
 
   const replySenderProfile = senderProfileFromRaw({ sender: raw.replyTo?.sender || raw.reply_to?.sender || {} })
 
+  const rawType = String(raw.type || raw.Type || '').toLowerCase()
   const contentText =
-    raw.type === 'image'
+    rawType === 'image'
       ? raw.caption || raw.text || (contentIsUrl ? '' : raw.content || '')
       : raw.content || raw.text || ''
 
   const sanitizedContent = cleanPreviewText(contentText)
+  let messageType = 'text'
+  if (rawType === 'image') {
+    messageType = 'image'
+  } else if (rawType === 'file') {
+    messageType = 'file'
+  } else if (possibleFileRel && !sanitizedContent) {
+    messageType = 'file'
+  }
 
   const rawId =
     raw.id ??
@@ -1319,7 +1290,7 @@ function normalizeMessage(raw) {
     id: rawId,
     read,
     content: sanitizedContent,
-    type: raw.type === 'image' ? 'image' : 'text',
+    type: messageType,
     fileAbsUrl: fileRel ? absUrl(fileRel) : null,
     senderId: String(senderId || ''),
     _sender: senderProfile.id
@@ -1396,6 +1367,14 @@ async function loadMessages() {
     })
 
     messages.value = mapped
+
+    if (mapped.length) {
+      const last = mapped[mapped.length - 1]
+      updateConversationMeta({
+        lastPreview: previewForNormalizedMessage(last),
+        lastTime: last._ts,
+      })
+    }
 
     await scrollToBottom(true)
   } catch (e) {
@@ -2189,188 +2168,6 @@ watch(convId, async () => {
 
 .chat-layout.has-group {
   flex-direction: row;
-}
-
-.list-pane {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  padding: var(--panel-pad);
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  height: 100%;
-  flex: 0 0 300px;
-  min-height: 0;
-  overflow: auto;
-}
-
-.list-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 3px;
-  padding: 4px 0 2px;
-}
-
-.list-title {
-  font-weight: 800;
-  color: #0f172a;
-}
-
-.list-search {
-  padding: 0 0 8px;
-}
-
-.search {
-  width: 100%;
-  border: 1px solid #e5e7eb;
-  border-radius: var(--radius-control);
-  padding: 10px 12px;
-  background: #ffffff;
-  font-size: var(--font-primary);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-.search:focus {
-  outline: none;
-  border-color: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
-}
-
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 3px;
-  padding: 4px 4px 2px;
-}
-
-.section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 3px;
-  padding: 4px 4px 2px;
-}
-
-.section-head.second {
-  margin-top: 4px;
-  border-top: 1px solid #e5e7eb;
-  padding-top: 10px;
-}
-
-.section-title {
-  margin: 0;
-  font-weight: 700;
-  color: #0f172a;
-  font-size: var(--font-secondary);
-}
-
-.badge {
-  display: inline-flex;
-  min-width: 28px;
-  height: 22px;
-  border-radius: 0;
-  padding: 0 8px;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #cbd5e1;
-  background: #fff;
-  font-size: var(--font-secondary);
-  color: #475569;
-  font-weight: 600;
-}
-
-.badge--secondary {
-  background: #f1f5f9;
-  border-color: #d8e0e8;
-}
-
-.list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.item {
-  background: #ffffff;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  padding: 10px 12px;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 3px;
-  transition: background 0.15s ease, border-color 0.15s ease;
-  cursor: pointer;
-}
-
-.item:hover {
-  background: #f9fafb;
-  border-color: #dfe3e8;
-}
-
-.item.active {
-  border-color: #9ae6b4;
-  background: #eefbf3;
-}
-
-.left {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.top {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.name {
-  font-weight: 600;
-  color: #111827;
-  font-size: var(--font-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.time {
-  font-size: var(--font-secondary);
-  color: #9ca3af;
-  white-space: nowrap;
-}
-
-.preview {
-  color: #7b8794;
-  font-size: var(--font-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.empty {
-  text-align: center;
-  color: #6b7280;
-  padding: 16px 0;
 }
 
 .chat-pane {

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -24,85 +24,21 @@
           </button>
 
           <div v-else class="panel">
-            <aside class="list-pane">
-              <div class="list-header">
-                <input
-                  v-model.trim="search"
-                  type="search"
-                  class="search"
-                  placeholder="search conversations"
-                  aria-label="Search conversations"
-                />
-              </div>
-
-              <div class="section">
-                <div class="section-head">
-                  <h3 class="section-title text-secondary">Direct</h3>
-                  <span class="badge">{{ privateConvs.length }}</span>
-                </div>
-
-                <ul class="list">
-                  <li
-                    v-for="c in privateConvs"
-                    :key="c.id"
-                    class="item"
-                    :class="{ active: selectedId === String(c.id) }"
-                    @click="open(c)"
-                  >
-                    <div class="left">
-                      <span v-if="!avatarFor(c)" class="avatar-fallback avatar-circle">{{ initials(c) }}</span>
-                      <img v-else class="avatar avatar-circle" :src="avatarFor(c)" alt="avatar" />
-                    </div>
-
-                    <div class="info">
-                      <div class="top">
-                        <div class="name">{{ displayName(c) }}</div>
-                        <div class="time">{{ fmtTime(c.last_time) }}</div>
-                      </div>
-                      <div class="bottom">
-                        <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
-                      </div>
-                    </div>
-
-                    <button class="del" @click.stop="warnDelete(c)">Delete</button>
-                  </li>
-
-                  <li v-if="!privateConvs.length" class="empty">No direct chats yet.</li>
-                </ul>
-              </div>
-              <div class="section">
-                <div class="section-head second">
-                  <h3 class="section-title text-secondary">Groups</h3>
-                  <span class="badge badge--secondary">{{ groupConvs.length }}</span>
-                </div>
-
-                <ul class="list">
-                  <li
-                    v-for="c in groupConvs"
-                    :key="c.id"
-                    class="item"
-                    :class="{ active: selectedId === String(c.id) }"
-                    @click="open(c)"
-                  >
-                    <div class="left">
-                      <span v-if="!avatarFor(c)" class="avatar-fallback avatar-circle">{{ initials(c) }}</span>
-                      <img v-else class="avatar avatar-circle" :src="avatarFor(c)" alt="avatar" />
-                    </div>
-                    <div class="info">
-                      <div class="top">
-                        <div class="name">{{ displayName(c) }}</div>
-                        <div class="time">{{ fmtTime(c.last_time) }}</div>
-                      </div>
-                      <div class="bottom">
-                        <div class="preview">{{ c.last_preview || 'No messages yet' }}</div>
-                      </div>
-                    </div>
-                    <button class="del" @click.stop="warnDelete(c)">Delete</button>
-                  </li>
-                  <li v-if="!groupConvs.length" class="empty">▸ You have no group chats. Create one ➕</li>
-                </ul>
-              </div>
-            </aside>
+            <ConversationList
+              v-model:search="search"
+              :private-convs="privateConvs"
+              :group-convs="groupConvs"
+              :selected-id="selectedId"
+              :display-name="displayName"
+              :avatar-for="avatarFor"
+              :initials="initials"
+              :fmt-time="fmtTime"
+              :show-delete="true"
+              variant="split"
+              empty-group-text="▸ You have no group chats. Create one ➕"
+              @select="open"
+              @delete="warnDelete"
+            />
 
             <div class="conversation-pane">
               <div class="preview-empty">
@@ -135,6 +71,7 @@
 import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import ErrorMsg from '@/components/ErrorMsg.vue'
+import ConversationList from '@/components/ConversationList.vue'
 
 import { getMyConversations, getAvatarUrl, deleteConversation, preferredDisplayName, initialsFor, normalizeUser } from '@/services/api'
 import { hydrateConversationList, upsertConversationMeta } from '@/services/conversationStore'
@@ -169,7 +106,11 @@ function previewForMessage(raw = {}) {
   if (raw?.deleted || raw?.isDeleted) return '[Deleted]'
 
   const type = String(raw?.type || raw?.Type || '').toLowerCase()
-  if (type === 'image') return '📷 Photo'
+  if (type === 'image') return '[image]'
+  if (type === 'file') return '[file]'
+
+  const fileUrl = raw?.fileUrl ?? raw?.file_url ?? raw?.FileUrl
+  if (fileUrl) return '[file]'
 
   const content = raw?.content ?? raw?.Content ?? ''
 
@@ -180,6 +121,60 @@ function conversationPreviewForMessage(raw = {}, conv = null) {
   const base = previewForMessage(raw)
   if (!base) return ''
   return base
+}
+
+function messageTime(raw = {}) {
+  return (
+    raw?.createdAt ||
+    raw?.created_at ||
+    raw?.CreatedAt ||
+    raw?.timestamp ||
+    raw?.Timestamp ||
+    null
+  )
+}
+
+function messageTimeValue(raw = {}) {
+  const value = messageTime(raw)
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.getTime()
+}
+
+function pickLastMessage(c) {
+  if (!c) return null
+
+  const fromKnownFields = c.lastMessage || c.last_message
+  if (fromKnownFields) return fromKnownFields
+
+  const list =
+    c.messages ||
+    c.Messages ||
+    c.messageList ||
+    c.message_list ||
+    c.items ||
+    c.list
+
+  if (!Array.isArray(list) || !list.length) return null
+
+  let best = null
+  let bestTime = null
+  list.forEach((msg) => {
+    const ts = messageTimeValue(msg)
+    if (ts !== null) {
+      if (bestTime === null || ts > bestTime) {
+        bestTime = ts
+        best = msg
+      }
+      return
+    }
+    if (!best) {
+      best = msg
+    }
+  })
+
+  return best || list[list.length - 1]
 }
 
 // Helper to read the current user identifier as a string.
@@ -257,16 +252,6 @@ async function load() {
     const root = res?.data?.items || res?.data || res
     const items = Array.isArray(root) ? root : (root?.items ?? root?.list ?? [])
 
-    const pickLastMessage = c => {
-      if (!c) return null
-
-      const fromKnownFields =
-        c.lastMessage ||
-        c.last_message
-
-      return fromKnownFields || null
-    }
-
     convs.value = (items || [])
       .map(c => {
         const isGroupType = c?.type === 'group' || !!(c?.groupId || c?.group_id || c?.group?.id)
@@ -276,14 +261,7 @@ async function load() {
           type: isGroupType ? 'group' : c?.type,
         })
 
-        const time =
-          last.createdAt ||
-          last.created_at ||
-          last.CreatedAt ||
-          last.timestamp ||
-          last.Timestamp ||
-          c.updatedAt || c.updated_at || c.UpdatedAt ||
-          c.createdAt || c.created_at || c.CreatedAt || null
+        const time = messageTime(last)
 
         return {
           ...c,
@@ -481,208 +459,6 @@ onUnmounted(() => {
   border: 1px solid var(--border);
   overflow: hidden;
 }
-.list-pane {
-  flex: 0 0 320px;
-  background: var(--panel);
-  border-right: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  padding: 16px;
-  gap: 10px;
-  min-height: 0;
-}
-
-.list-header {
-  padding: 4px 0 8px;
-}
-
-.search {
-  width: 100%;
-  border: 1px solid #e5e7eb;
-  border-radius: var(--radius-control);
-  padding: 10px 12px;
-  background: #ffffff;
-  font-size: var(--font-primary);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-.search:focus {
-  outline: none;
-  border-color: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
-}
-
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-height: 0;
-}
-
-.section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 4px 4px 2px;
-}
-
-.section-head.second {
-  margin-top: 4px;
-  border-top: 1px solid #e5e7eb;
-  padding-top: 10px;
-}
-
-.section-title {
-  margin: 0;
-  font-weight: 700;
-  color: #0f172a;
-  font-size: var(--font-secondary);
-}
-
-.badge {
-  display: inline-flex;
-  min-width: 28px;
-  height: 22px;
-  border-radius: 0;
-  padding: 0 8px;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #cbd5e1;
-  background: #fff;
-  font-size: var(--font-secondary);
-  color: #475569;
-  font-weight: 600;
-}
-
-.badge--secondary {
-  background: #f1f5f9;
-  border-color: #d8e0e8;
-}
-
-.list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  flex: 1 1 auto;
-  overflow-y: auto;
-  max-height: 100%;
-  min-height: 0;
-}
-
-.item {
-  background: #ffffff;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  padding: 14px 16px;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 14px;
-  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
-  position: relative;
-}
-
-.item:hover {
-  background: rgba(34, 197, 94, 0.1);
-  border-color: rgba(34, 197, 94, 0.35);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
-}
-
-.item.active {
-  background: #dcfce7;
-  border-color: #22c55e;
-}
-
-.item.active::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 10px;
-  bottom: 10px;
-  width: 3px;
-  background: #22c55e;
-}
-
-.left {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.top {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  gap: 12px;
-}
-
-.name {
-  font-weight: 600;
-  color: #0f172a;
-  font-size: var(--font-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.handle {
-  color: #64748b;
-  font-size: var(--font-secondary);
-}
-
-.time {
-  font-size: 0.92rem;
-  color: #64748b;
-  white-space: nowrap;
-}
-
-.preview {
-  color: #64748b;
-  font-size: 0.92rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.del {
-  border: 0;
-  border-radius: var(--radius-control);
-  padding: 0.35rem 0.7rem;
-  font-size: var(--font-secondary);
-  color: #fff;
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  transition: 0.2s;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.item:hover .del,
-.item:focus-within .del {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.del:hover {
-  opacity: 0.9;
-}
-.empty {
-  text-align: center;
-  color: #6b7280;
-  padding: 16px 0;
-}
-
 .conversation-pane {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
### Motivation
- Make the conversation sidebar update immediately when messages are loaded, sent, or received so previews and timestamps stay current without a manual refresh. 
- Support heterogeneous backend message shapes by picking the true last message from different payload layouts. 
- Unify conversation list UI across pages by using a shared list component for consistent rendering. 

### Description
- Add `ConversationList.vue` and replace inline conversation list markup in `ChatView.vue` and `ConversationsView.vue` with the shared `ConversationList` component. 
- Improve message normalization in `ChatView.vue` by detecting `image`/`file`/`text` via `normalizeMessage` and exposing `previewForNormalizedMessage` for consistent preview rendering. 
- Add `messageTime`, `messageTimeValue`, and `pickLastMessage` helpers to derive the most recent message across different backend shapes and use them when building the normalized conversation list. 
- After loading messages in `loadMessages`, call `updateConversationMeta` with `lastPreview` and `lastTime` so the sidebar metadata is updated and triggers reactivity. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961707dbbac8331809c5f8a1bfcfe0d)