### PR TITLE
Unify Contacts UI with Chats layout and styling

### DIFF
--- a/webui/src/assets/main.css
+++ b/webui/src/assets/main.css
@@ -98,6 +98,11 @@ body{
   padding: 24px;
 }
 
+.page {
+  min-height: 100vh;
+  display: flex;
+}
+
 /* Reusable card (dark to light) */
 .card{
   width: 100%;
@@ -220,6 +225,10 @@ a:hover{ text-decoration: underline; }
   background:#f4f7fb !important;
   border-right:1px solid var(--border);
   color:var(--text);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .content{
   background:var(--bg) !important;

--- a/webui/src/components/AppLayout.vue
+++ b/webui/src/components/AppLayout.vue
@@ -14,7 +14,7 @@ import Sidebar from '@/components/Sidebar.vue'
 <style scoped>
 .app-layout {
   display: grid;
-  grid-template-columns: 230px 1fr;
+  grid-template-columns: 240px 1fr;
   min-height: 100vh;
   height: 100%;
   width: 100%;

--- a/webui/src/components/ConversationList.vue
+++ b/webui/src/components/ConversationList.vue
@@ -144,7 +144,7 @@ function emitDelete(c) {
 
 <style scoped>
 .list-pane {
-  flex: 0 0 320px;
+  flex: 0 0 360px;
   background: var(--panel);
   border: 1px solid var(--border);
   display: flex;
@@ -190,8 +190,8 @@ function emitDelete(c) {
 
 .search:focus {
   outline: none;
-  border-color: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
+  border-color: #32d583;
+  box-shadow: 0 0 0 3px rgba(50, 213, 131, 0.2);
 }
 
 .section {
@@ -270,14 +270,14 @@ function emitDelete(c) {
 }
 
 .item:hover {
-  background: rgba(34, 197, 94, 0.1);
-  border-color: rgba(34, 197, 94, 0.35);
+  background: #c6f6d5;
+  border-color: rgba(50, 213, 131, 0.6);
   box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
 }
 
 .item.active {
-  background: #dcfce7;
-  border-color: #22c55e;
+  background: #32d583;
+  border-color: #32d583;
 }
 
 .item.active::before {
@@ -287,7 +287,16 @@ function emitDelete(c) {
   top: 10px;
   bottom: 10px;
   width: 3px;
-  background: #22c55e;
+  background: #16a34a;
+}
+
+.item.active .name {
+  color: #0f172a;
+}
+
+.item.active .time,
+.item.active .preview {
+  color: #065f46;
 }
 
 .left {

--- a/webui/src/components/Sidebar.vue
+++ b/webui/src/components/Sidebar.vue
@@ -51,15 +51,17 @@ async function logout() {
 
 <style scoped>
 .sidebar {
-  width: 230px;
-  flex: 0 0 230px;
+  width: 240px;
+  flex: 0 0 240px;
   min-height: 100vh;
+  height: 100vh;
   position: static;
   background: linear-gradient(180deg, #ffffff, #f8fafc);
   border-right: 1px solid #e2e8f0;
   padding: 18px 14px;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
 .brand {
@@ -125,7 +127,7 @@ async function logout() {
 .footer {
   border-top: 1px solid #e2e8f0;
   padding-top: 16px;
-  margin-top: auto;
+  margin-top: 0;
 }
 .logout {
   width: 100%;
@@ -148,6 +150,7 @@ async function logout() {
     z-index: 3;
     width: 100%;
     min-height: auto;
+    height: auto;
     flex: 0 0 auto;
     flex-direction: row;
     align-items: center;

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -429,6 +429,10 @@ export async function getMyConversations() {
   return unwrap(await get('/conversations'))
 }
 
+export async function fetchConversations() {
+  return getMyConversations()
+}
+
 // Fetch members directly; fall back to group lookup when the endpoint is missing.
 export async function getConversationMembers(conversationId) {
   const id = String(conversationId || '').trim();
@@ -690,6 +694,7 @@ const api = {
   startConversation,
   startPrivateConversation,
   getMyConversations,
+  fetchConversations,
   deleteConversation,
 
   // groups

--- a/webui/src/views/ContactsView.vue
+++ b/webui/src/views/ContactsView.vue
@@ -12,7 +12,7 @@
             <div class="list-search">
               <input
                 v-model.trim="q"
-                class="input"
+                class="search"
                 type="text"
                 placeholder="Search by name/username"
                 @keyup.enter="onSearch"
@@ -74,9 +74,9 @@
                   />
                 </svg>
               </div>
-              <h2 class="preview-title">Select a contact to start chatting</h2>
+              <h2 class="preview-title">Choose a chat to view messages</h2>
               <p class="preview-description">
-                Your chats will appear here once you open a conversation.
+                Your chats will appear here once you start a conversation.
               </p>
             </div>
           </div>
@@ -378,24 +378,29 @@ onMounted(() => {
 
 <style scoped>
 .page{
-  min-height:100%;
-  height:100%;
-  width:100%;
-  min-width:0;
-  flex:1 1 auto;
-  display:flex;
-  flex-direction:column;
-  background:
-    radial-gradient(1200px 800px at 10% -10%, #f3f8ff 0, transparent 60%),
-    radial-gradient(1000px 700px at 110% 0%, #eef6ff 0, transparent 55%),
-    linear-gradient(180deg, #ffffff, #f7fafe);
+  min-height: 100vh;
+  height: 100vh;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  background: #e5e7eb;
+  color: #1f2937;
 }
 .topbar{
-  height:56px; display:flex; align-items:center; justify-content:space-between;
-  padding:0 18px; border-bottom:1px solid rgba(20,100,60,.08); background:#fff8; backdrop-filter: blur(6px);
+  height: 56px;
+  display: grid;
+  place-items: center;
+  padding: 0 18px;
+  border-bottom: 1px solid rgba(20, 100, 60, 0.06);
+  background: #f8fafc;
 }
 .title{
-  font-weight:800; color:#0f172a;
+  font-weight: 700;
+  font-size: var(--font-title);
+  color: #0f172a;
+  text-align: center;
 }
 
 .workspace{
@@ -422,7 +427,7 @@ onMounted(() => {
   align-items:center;
   gap:8px;
 }
-.input{
+.search{
   flex:1;
   border:1px solid #e5e7eb;
   border-radius:var(--radius-control);
@@ -432,40 +437,44 @@ onMounted(() => {
   font-size:var(--font-primary);
   transition:border-color .15s ease, box-shadow .15s ease;
 }
-.input:focus{ border-color:#22c55e; box-shadow:0 0 0 3px rgba(34,197,94,.15); }
+.search:focus{
+  border-color:#32d583;
+  box-shadow:0 0 0 3px rgba(50, 213, 131, 0.2);
+}
 .btn{
   border:0;
   border-radius:var(--radius-control);
   color:#fff;
   padding:0.45rem 0.75rem;
   white-space:nowrap;
-  background:#34d399;
-  box-shadow:0 .35rem .8rem rgba(16,185,129,.2);
+  background:#32d583;
+  box-shadow:0 .35rem .8rem rgba(50, 213, 131, 0.22);
   transition:transform .15s ease, box-shadow .15s ease, background .15s ease;
   font-weight:700;
 }
 .btn:hover{
-  background:#10b981;
-  box-shadow:0 .5rem 1rem rgba(16,185,129,.32);
+  background:#c6f6d5;
+  color:#065f46;
+  box-shadow:0 .5rem 1rem rgba(15, 118, 110, 0.18);
   transform:translateY(-1px);
 }
 .btn:disabled { opacity:.6; cursor:not-allowed; }
-.btn:disabled:hover { background:#34d399; box-shadow:0 .35rem .8rem rgba(16,185,129,.2); transform:none; }
+.btn:disabled:hover { background:#32d583; color:#fff; box-shadow:0 .35rem .8rem rgba(50, 213, 131, 0.22); transform:none; }
 .btn-search{
-  background:#fff;
-  color:#16a34a;
-  border:1px solid #bbf7d0;
+  background:#e5e7eb;
+  color:#1f2937;
+  border:1px solid #e5e7eb;
   box-shadow:none;
   padding:8px 12px;
 }
 .btn-search:hover{
-  background:#ecfdf3;
-  border-color:#22c55e;
-  color:#166534;
+  background:#c6f6d5;
+  border-color:#32d583;
+  color:#065f46;
   box-shadow:0 8px 16px rgba(15,23,42,0.06);
 }
 .btn-outline{
-  background:#fff; color:#334155; border:1px solid #cbd5e1; box-shadow:none;
+  background:#e5e7eb; color:#1f2937; border:1px solid #e5e7eb; box-shadow:none;
 }
 .btn.icon-only{
   width:36px; height:36px; padding:0;
@@ -490,7 +499,7 @@ onMounted(() => {
   overflow:hidden;
 }
 .list-pane{
-  flex:0 0 320px;
+  flex:0 0 360px;
   background:var(--panel);
   border-right:1px solid var(--border);
   display:flex;
@@ -498,9 +507,19 @@ onMounted(() => {
   padding:16px;
   gap:10px;
   min-height:0;
-  overflow:auto;
+  overflow:hidden;
 }
-.list{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; min-height:0; }
+.list{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  min-height:0;
+  flex:1 1 auto;
+  overflow-y:auto;
+}
 .item{
   background:#ffffff;
   border:1px solid var(--border);
@@ -517,13 +536,13 @@ onMounted(() => {
   cursor:pointer;
 }
 .item:hover{
-  background:rgba(34, 197, 94, 0.1);
-  border-color:rgba(34, 197, 94, 0.35);
+  background:#c6f6d5;
+  border-color:rgba(50, 213, 131, 0.6);
   box-shadow:0 6px 16px rgba(15,23,42,0.08);
 }
 .item.active{
-  background:#dcfce7;
-  border-color:#22c55e;
+  background:#32d583;
+  border-color:#32d583;
 }
 .item.active::before{
   content:'';
@@ -532,7 +551,14 @@ onMounted(() => {
   top:10px;
   bottom:10px;
   width:3px;
-  background:#22c55e;
+  background:#16a34a;
+}
+.item.active .name{
+  color:#0f172a;
+}
+.item.active .time,
+.item.active .preview{
+  color:#065f46;
 }
 .item.disabled{
   cursor:not-allowed;
@@ -541,10 +567,10 @@ onMounted(() => {
 .left{ display:flex; align-items:center; justify-content:center; }
 .avatar,
 .avatar-fallback{
-  width:44px;
-  height:44px;
+  width:32px;
+  height:32px;
   border-radius:50%;
-  flex:0 0 44px;
+  flex:0 0 32px;
 }
 .avatar{
   object-fit:cover;
@@ -567,7 +593,7 @@ onMounted(() => {
 }
 .name{ font-weight:600; color:#0f172a; font-size:var(--font-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .time{
-  color:#94a3b8;
+  color:#64748b;
   font-size:.85rem;
   white-space:nowrap;
 }

--- a/webui/src/views/GroupView.vue
+++ b/webui/src/views/GroupView.vue
@@ -141,6 +141,7 @@ import {
   addToGroup,
   removeFromGroup,
   leaveGroup,
+  fetchConversations,
   getAvatarUrl,
   preferredDisplayName,
   normalizeUser,
@@ -511,6 +512,8 @@ async function onLeave(id) {
         })
       )
     }
+    await fetchConversations()
+    router.push('/conversations')
     await loadList()
     emitConversationsReload()
   } catch (e) {


### PR DESCRIPTION
### Motivation
- Make the Contacts page feel identical to the Chats pages by using the same 3-column layout, widths, and visual language.
- Fix layout height issues so the sidebar fills the viewport and controls (Logout) stay pinned.
- Use a single color palette (green primary) and shared list styling for hover/active states and avatar fallbacks.
- Ensure leaving a group removes it from the conversations list and navigates back to conversations.

### Description
- Add global layout rules to `webui/src/assets/main.css` (`.page` min-height and `.sidebar` full-height + spacing) to keep pages consistent and Sidebar pinned.
- Standardize sidebar width to `240px` in `AppLayout.vue` and `Sidebar.vue` and adjust sidebar height/justify behavior to stretch full height.
- Make list panel width fixed to `360px` and unify list styles in `ConversationList.vue` and `ContactsView.vue` (hover/light-green tint, active green background, focus ring color, avatar fallback sizing, spacing and padding).`
- Replace Contacts search input to use the same search control styling as Chats, adjust scroll/overflow on lists, and make the Contacts empty preview copy match the Chats empty state.
- Add `fetchConversations()` wrapper in `webui/src/services/api.js` and call it from `GroupView.vue` after `leaveGroup()` and then `router.push('/conversations')` so the UI refreshes and the user is redirected.

### Testing
- Launched the dev server with `yarn dev` and opened `/contacts` in a headless browser, capturing a screenshot to verify the three-column layout and styling (Playwright screenshot completed). 
- No automated unit tests were present or run for these UI/CSS changes; the manual automated smoke run above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617e15b58c83318d92342456ed3a6f)