### PR TITLE
Remove page topbars; refine sidebar, conversation list, and chat media handling

### DIFF
--- a/webui/src/components/ConversationList.vue
+++ b/webui/src/components/ConversationList.vue
@@ -48,7 +48,10 @@
           <button v-if="showDelete" class="del" @click.stop="emitDelete(c)">Delete</button>
         </li>
 
-        <li v-if="!privateConvs.length" class="empty">{{ emptyDirectText }}</li>
+        <li v-if="!privateConvs.length" class="empty">
+          <span class="empty-icon" aria-hidden="true">💬</span>
+          <span>{{ emptyDirectText }}</span>
+        </li>
       </ul>
     </div>
 
@@ -81,7 +84,10 @@
           </div>
           <button v-if="showDelete" class="del" @click.stop="emitDelete(c)">Delete</button>
         </li>
-        <li v-if="!groupConvs.length" class="empty">{{ emptyGroupText }}</li>
+        <li v-if="!groupConvs.length" class="empty">
+          <span class="empty-icon" aria-hidden="true">👥</span>
+          <span>{{ emptyGroupText }}</span>
+        </li>
       </ul>
     </div>
 
@@ -210,9 +216,9 @@ function emitDelete(c) {
 }
 
 .section-head.second {
-  margin-top: 4px;
+  margin-top: 12px;
   border-top: 1px solid #e5e7eb;
-  padding-top: 10px;
+  padding-top: 14px;
 }
 
 .section-title {
@@ -314,8 +320,7 @@ function emitDelete(c) {
 }
 
 .top {
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   align-items: center;
   gap: 12px;
 }
@@ -327,9 +332,11 @@ function emitDelete(c) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .time {
+  margin-left: auto;
   font-size: 0.92rem;
   color: #64748b;
   white-space: nowrap;
@@ -369,5 +376,14 @@ function emitDelete(c) {
   text-align: center;
   color: #6b7280;
   padding: 16px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.empty-icon {
+  font-size: 1rem;
 }
 </style>

--- a/webui/src/components/Sidebar.vue
+++ b/webui/src/components/Sidebar.vue
@@ -61,7 +61,7 @@ async function logout() {
   padding: 18px 14px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 16px;
 }
 
 .brand {
@@ -108,12 +108,16 @@ async function logout() {
 }
 
 .link {
-  display: block;
-  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 12px;
   color: #0f172a;
   font-weight: 500;
   text-decoration: none;
   transition: 0.2s;
+  border-radius: 10px;
 }
 .link:hover {
   background: #f1f5f9;
@@ -125,9 +129,9 @@ async function logout() {
 }
 
 .footer {
+  margin-top: auto;
   border-top: 1px solid #e2e8f0;
   padding-top: 16px;
-  margin-top: 0;
 }
 .logout {
   width: 100%;
@@ -182,7 +186,7 @@ async function logout() {
   }
 
   .footer {
-    margin: 0;
+    margin: 0 0 0 auto;
     padding-top: 0;
     border-top: 0;
   }

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -1,10 +1,6 @@
 <!-- src/views/ChatView.vue: Chat experience with in-place conversation switching. -->
 <template>
   <div class="page">
-    <header class="topbar">
-      <div class="title">Chats</div>
-    </header>
-
     <section class="workspace">
       <div class="content-inner">
         <ErrorMsg v-if="err" :text="err" class="mb-2" />
@@ -136,8 +132,30 @@
                             </div>
                           </button>
 
-                          <div v-if="m.fileAbsUrl" class="img-wrap">
-                            <img :src="m.fileAbsUrl" class="img" />
+                          <div
+                            v-if="m.fileAbsUrl"
+                            class="img-wrap"
+                            :class="{
+                              'is-loading': mediaStatusFor(m) === 'loading',
+                              'is-error': mediaStatusFor(m) === 'error'
+                            }"
+                          >
+                            <div v-if="mediaStatusFor(m) !== 'loaded'" class="img-state">
+                              <span
+                                v-if="mediaStatusFor(m) === 'error'"
+                                class="img-fallback"
+                              >
+                                🖼️ Image failed to load
+                              </span>
+                              <span v-else class="img-spinner" aria-label="Loading image"></span>
+                            </div>
+                            <img
+                              :src="m.fileAbsUrl"
+                              class="img"
+                              :class="{ 'is-hidden': mediaStatusFor(m) !== 'loaded' }"
+                              @load="onMediaLoad(m)"
+                              @error="onMediaError(m)"
+                            />
                           </div>
 
                           <div
@@ -564,6 +582,7 @@ const me = computed(() => currentUser.value)
 const meId = computed(() => String(me.value?.id || ''))
 const myAvatar = computed(() => getAvatarUrl(me.value || {}))
 const brokenAvatars = ref(new Set())
+const mediaStatus = ref({})
 
 const currentConv = ref(null)
 const isGroup = ref(false)
@@ -677,7 +696,7 @@ function previewForMessage(raw = {}) {
   const text = formatPreviewText(content)
   const isFile = type === 'file'
   const isImage = type === 'image'
-  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[img]' : '')
+  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[image]' : '')
 
   if (mediaLabel && text) return `${mediaLabel} ${text}`
   if (mediaLabel) return mediaLabel
@@ -698,7 +717,7 @@ function previewForNormalizedMessage(message) {
   const text = formatPreviewText(message.content)
   const isFile = message.type === 'file'
   const isImage = message.type === 'image'
-  const mediaLabel = isFile ? '[file]' : (isImage || message.fileAbsUrl ? '[img]' : '')
+  const mediaLabel = isFile ? '[file]' : (isImage || message.fileAbsUrl ? '[image]' : '')
 
   if (mediaLabel && text) return `${mediaLabel} ${text}`
   if (mediaLabel) return mediaLabel
@@ -1018,6 +1037,28 @@ function onAvatarError(url) {
 function avatarUrlForMessage(m) {
   const url = avatarFor(m)
   return isAvatarBroken(url) ? '' : url
+}
+
+function mediaKey(m) {
+  return String(m?.id || m?.fileAbsUrl || '')
+}
+
+function mediaStatusFor(m) {
+  if (!m?.fileAbsUrl) return 'loaded'
+  const key = mediaKey(m)
+  return mediaStatus.value[key] || 'loading'
+}
+
+function onMediaLoad(m) {
+  const key = mediaKey(m)
+  if (!key) return
+  mediaStatus.value = { ...mediaStatus.value, [key]: 'loaded' }
+}
+
+function onMediaError(m) {
+  const key = mediaKey(m)
+  if (!key) return
+  mediaStatus.value = { ...mediaStatus.value, [key]: 'error' }
 }
 
 const myAvatarUrl = computed(() => (isAvatarBroken(myAvatar.value) ? '' : myAvatar.value))
@@ -2105,25 +2146,6 @@ watch(convId, async () => {
   color: #1f2937;
 }
 
-.topbar {
-  height: 56px;
-  display: grid;
-  place-items: center;
-  padding: 0 18px;
-  border-bottom: 1px solid rgba(20, 100, 60, 0.06);
-  background: #f8fafc;
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-.title {
-  font-weight: 700;
-  font-size: var(--font-title);
-  color: #0f172a;
-  text-align: center;
-}
-
 .chat-header {
   position: sticky;
   top: 0;
@@ -2244,6 +2266,7 @@ watch(convId, async () => {
   flex-direction: column;
   min-height: 0;
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .group-panel {
@@ -2709,6 +2732,9 @@ img.member-avatar {
 
 .img-wrap {
   display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
   margin-bottom: 6px;
   max-width: 260px;
   max-height: 260px;
@@ -2722,6 +2748,52 @@ img.member-avatar {
   height: auto;
   object-fit: contain;
   border-radius: var(--radius-bubble);
+}
+
+.img.is-hidden {
+  opacity: 0;
+}
+
+.img-wrap.is-loading .img {
+  filter: blur(6px);
+  opacity: 0.7;
+}
+
+.img-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: var(--radius-bubble);
+  pointer-events: none;
+}
+
+.img-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba(15, 23, 42, 0.2);
+  border-top-color: #22c55e;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+.img-fallback {
+  font-size: 0.8rem;
+  color: #475569;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 6px 8px;
+  text-align: center;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .text-block {
@@ -2807,6 +2879,8 @@ img.member-avatar {
   gap: 6px;
   margin-top: var(--space-2);
   align-items: center;
+  flex-wrap: nowrap;
+  overflow-x: auto;
 }
 
 .icon-btn {
@@ -2823,6 +2897,7 @@ img.member-avatar {
   align-items: center;
   justify-content: center;
   color: #334155;
+  flex: 0 0 auto;
 }
 
 .icon-btn:focus-visible,

--- a/webui/src/views/ContactsView.vue
+++ b/webui/src/views/ContactsView.vue
@@ -1,10 +1,6 @@
 <!-- src/views/ContactsView.vue: Contact directory for launching private chats. -->
 <template>
   <div class="page">
-    <header class="topbar">
-      <div class="title">Contacts</div>
-    </header>
-
     <section class="workspace">
       <div class="content-inner">
         <div class="panel">
@@ -56,29 +52,11 @@
                   </div>
                 </div>
               </li>
-              <li v-if="!sortedUsers.length" class="empty">No users.</li>
+              <li v-if="!sortedUsers.length" class="empty">
+                <span class="empty-icon" aria-hidden="true">👥</span>
+                <span>No users.</span>
+              </li>
             </ul>
-          </div>
-
-          <div class="conversation-pane">
-            <div class="preview-empty">
-              <div class="preview-icon" aria-hidden="true">
-                <svg viewBox="0 0 48 48" role="img" focusable="false">
-                  <path
-                    d="M15 18h18M15 24h12M6 22c0-7.732 6.268-14 14-14h8c7.732 0 14 6.268 14 14s-6.268 14-14 14h-8l-8 6v-8c-3.314-2.564-6-7.106-6-12z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </div>
-              <h2 class="preview-title">Choose a chat to view messages</h2>
-              <p class="preview-description">
-                Your chats will appear here once you start a conversation.
-              </p>
-            </div>
           </div>
         </div>
       </div>
@@ -156,7 +134,7 @@ function previewForMessage(raw = {}) {
   const text = formatPreviewText(content)
   const isFile = type === 'file'
   const isImage = type === 'image'
-  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[img]' : '')
+  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[image]' : '')
 
   if (mediaLabel && text) return `${mediaLabel} ${text}`
   if (mediaLabel) return mediaLabel
@@ -388,21 +366,6 @@ onMounted(() => {
   background: #e5e7eb;
   color: #1f2937;
 }
-.topbar{
-  height: 56px;
-  display: grid;
-  place-items: center;
-  padding: 0 18px;
-  border-bottom: 1px solid rgba(20, 100, 60, 0.06);
-  background: #f8fafc;
-}
-.title{
-  font-weight: 700;
-  font-size: var(--font-title);
-  color: #0f172a;
-  text-align: center;
-}
-
 .workspace{
   flex:1 1 auto;
   margin:0;
@@ -461,9 +424,9 @@ onMounted(() => {
 .btn:disabled { opacity:.6; cursor:not-allowed; }
 .btn:disabled:hover { background:#32d583; color:#fff; box-shadow:0 .35rem .8rem rgba(50, 213, 131, 0.22); transform:none; }
 .btn-search{
-  background:#e5e7eb;
-  color:#1f2937;
-  border:1px solid #e5e7eb;
+  background:#f1f5f9;
+  color:#0f172a;
+  border:1px solid #e2e8f0;
   box-shadow:none;
   padding:8px 12px;
 }
@@ -499,9 +462,9 @@ onMounted(() => {
   overflow:hidden;
 }
 .list-pane{
-  flex:0 0 360px;
+  flex:1 1 auto;
   background:var(--panel);
-  border-right:1px solid var(--border);
+  border-right:0;
   display:flex;
   flex-direction:column;
   padding:16px;
@@ -586,64 +549,29 @@ onMounted(() => {
 }
 .info{ flex:1; min-width:0; display:flex; flex-direction:column; gap:2px; }
 .top{
-  display:grid;
-  grid-template-columns:1fr auto;
+  display:flex;
   align-items:center;
   gap:12px;
 }
-.name{ font-weight:600; color:#0f172a; font-size:var(--font-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.name{ font-weight:600; color:#0f172a; font-size:var(--font-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0; }
 .time{
   color:#64748b;
   font-size:.85rem;
   white-space:nowrap;
+  margin-left:auto;
 }
 .preview{ color:#64748b; font-size:.92rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.empty{ text-align:center; color:#64748b }
-.conversation-pane{
-  flex:1 1 auto;
-  min-width:0;
-  background:var(--panel);
-  display:flex;
-  align-items:flex-start;
-  justify-content:center;
-  padding:24px;
-  border-left:1px solid var(--border);
-}
-.preview-empty{
-  max-width:520px;
-  margin-top:12px;
+.empty{
   text-align:center;
+  color:#64748b;
   display:flex;
-  flex-direction:column;
-  align-items:center;
-  gap:12px;
-  color:#1f2937;
-}
-.preview-icon{
-  width:64px;
-  height:64px;
-  border-radius:22px;
-  display:inline-flex;
   align-items:center;
   justify-content:center;
-  color:#16a34a;
-  background:linear-gradient(135deg, rgba(34, 197, 94, 0.18), rgba(22, 163, 74, 0.1));
-  box-shadow:0 10px 24px rgba(22, 163, 74, 0.12);
+  gap:8px;
+  font-weight:600;
 }
-.preview-icon svg{
-  width:32px;
-  height:32px;
-}
-.preview-title{
-  font-size:1.4rem;
-  font-weight:800;
-  margin:0;
-  color:#1f2937;
-}
-.preview-description{
-  margin:0;
-  color:#475569;
-  font-size:var(--font-primary);
+.empty-icon{
+  font-size:1rem;
 }
 @media (max-width: 900px){
   .panel{
@@ -652,10 +580,7 @@ onMounted(() => {
   .list-pane{
     flex:0 0 auto;
     border-right:0;
-    border-bottom:1px solid var(--border);
-  }
-  .conversation-pane{
-    border-left:0;
+    border-bottom:0;
   }
 }
 </style>

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -1,12 +1,6 @@
 <!-- src/views/ConversationsView.vue: Conversation directory showing private and group chats. -->
 <template>
   <div class="page">
-    <header class="topbar">
-      <div>
-        <div class="title">Chats</div>
-      </div>
-    </header>
-
     <div v-if="toastMessage" class="toast" role="status" aria-live="polite">
       <span class="checkmark">✓</span>
       <span>{{ toastMessage }}</span>
@@ -111,7 +105,7 @@ function previewForMessage(raw = {}) {
   const text = formatPreviewText(content)
   const isFile = type === 'file'
   const isImage = type === 'image'
-  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[img]' : '')
+  const mediaLabel = isFile ? '[file]' : (isImage || fileUrl ? '[image]' : '')
 
   if (mediaLabel && text) return `${mediaLabel} ${text}`
   if (mediaLabel) return mediaLabel
@@ -405,25 +399,6 @@ onUnmounted(() => {
   background: #e5e7eb;
   color: #1f2937;
 }
-.topbar {
-  height: 56px;
-  display: grid;
-  place-items: center;
-  padding: 0 18px;
-  border-bottom: 1px solid rgba(20, 100, 60, 0.06);
-  background: #f8fafc;
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-.title {
-  font-weight: 700;
-  font-size: var(--font-title);
-  color: #0f172a;
-  text-align: center;
-}
-
 .workspace {
   flex: 1 1 auto;
   display: flex;
@@ -545,13 +520,6 @@ onUnmounted(() => {
 }
 
 @media (max-width: 992px) {
-  .topbar {
-    height: auto;
-    align-items: flex-start;
-    grid-template-columns: 1fr;
-    padding: 10px 14px;
-  }
-
   .workspace {
     padding: 12px;
   }

--- a/webui/src/views/GroupView.vue
+++ b/webui/src/views/GroupView.vue
@@ -1,10 +1,6 @@
 <!-- src/views/GroupView.vue: Group directory with creation and management panels. -->
 <template>
   <div class="page">
-    <header class="topbar">
-      <div class="title">Groups</div>
-    </header>
-
     <section class="content">
       <ErrorMsg v-if="err" :text="err" class="mb-2" />
       <p v-else-if="notice" class="notice">{{ notice }}</p>
@@ -497,8 +493,14 @@ async function onLeave(id) {
   busy.value = true
   try {
     await leaveGroup(id)
-    if (manageId.value === id) manageId.value = ''
     const target = groups.value.find(g => String(g.id) === String(id))
+    groups.value = groups.value.filter(g => String(g.id) !== String(id))
+    if (manageId.value === id) {
+      manageId.value = ''
+      editName.value = ''
+      addIds.value = ''
+      manageMembers.value = []
+    }
     await refreshGroupMeta(id, {
       conversationId: target?.conversation_id,
       name: target?.name,
@@ -543,11 +545,6 @@ onMounted(async () => {
     linear-gradient(180deg,#ffffff,#f7fafe);
   color:#0f172a;
 }
-.topbar{
-  height:56px; display:flex; align-items:center; justify-content:space-between;
-  padding:0 18px; border-bottom:1px solid rgba(20,100,60,.08); background:#fff8; backdrop-filter: blur(6px);
-}
-.title{ font-weight:800; color:#0f172a; }
 .content{ max-width:1100px; margin:0 auto; padding:16px; }
 
 .card{
@@ -624,6 +621,9 @@ onMounted(async () => {
 .member-list{
   display:grid;
   gap:8px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 .member{
   display:grid;
@@ -635,7 +635,14 @@ onMounted(async () => {
 .member-name{ font-weight:600; color:#0f172a }
 .btn.ghost{
   background:#f8fafc;
-  color:#0f172a;
+  color:#64748b;
   box-shadow:none;
+  border:1px solid #e2e8f0;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+.btn.ghost:hover{
+  color:#dc2626;
+  background:#fee2e2;
+  border-color:#fecaca;
 }
 </style>

--- a/webui/src/views/NewGroupView.vue
+++ b/webui/src/views/NewGroupView.vue
@@ -1,10 +1,6 @@
 <!-- src/views/NewGroupView.vue: Guided flow for creating a new group chat. -->
 <template>
   <div class="page">
-    <header class="topbar">
-      <div class="title">Create Group</div>
-    </header>
-
     <section class="content">
       <ErrorMsg v-if="err" :text="err" class="mb-3" />
 
@@ -234,19 +230,6 @@ async function create() {
     radial-gradient(1000px 700px at 110% 0%, #eef6ff 0, transparent 55%),
     linear-gradient(180deg, #ffffff, #f7fafe);
 }
-.topbar {
-  height: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 18px;
-  border-bottom: 1px solid #e2e8f0;
-  background: #fff;
-}
-.title {
-  font-weight: 800; color: #0f172a;
-}
-
 .content {
   flex: 1 1 auto;
   padding: 24px;

--- a/webui/src/views/ProfileView.vue
+++ b/webui/src/views/ProfileView.vue
@@ -2,12 +2,6 @@
 <template>
   <div class="page">
     <main class="wrap">
-      <div class="page-title">
-        <div>
-          <h2 class="title">My Profile</h2>
-          <p class="subtitle">Manage how you appear across chats and groups.</p>
-        </div>
-      </div>
 
       <ErrorMsg v-if="err" :text="err" class="mb-3" />
 
@@ -337,28 +331,11 @@ function handleError(e, fallback) {
 }
 .wrap {
   flex: 1 1 auto;
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 16px 24px 24px;
-  width: 100%;
-}
-.page-title {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-.title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0 0 4px;
-}
-.subtitle {
+  max-width: 760px;
   margin: 0;
-  color: #64748b;
-  font-size: 0.95rem;
+  padding: 24px 32px;
+  width: 100%;
+  align-self: flex-start;
 }
 
 .card {


### PR DESCRIPTION
### Motivation
- Page-level title bars (e.g. `Chats`, `Contacts`, `Profile`, `Create Group`, `Groups`) consumed vertical space and caused layout shifting when message lists grew. 
- The left sidebar highlight is sufficient to indicate the active section so the large page headers were unnecessary. 
- Conversation/contacts list previews and timestamps were inconsistent and needed alignment and empty-state clarity. 
- Chat media and action layout needed more robust loading/fallback behavior and stable scroll/footer behavior for long threads. 

### Description
- Removed page-level header/title markup and related CSS from conversation, contacts, profile, new group, and groups views so content starts directly under the sidebar navigation. 
- Updated `Sidebar.vue` to use a column flex layout with gaps, made nav links consistent (`display: flex`, `min-height`, `border-radius`), and pushed logout to the bottom using `margin-top: auto`. 
- Standardized conversation list and contacts list presentation in `ConversationList.vue` and `ContactsView.vue` by right-aligning timestamps, adjusting section spacing, adding compact empty-state rows with icons, and matching search button styling. 
- Improved chat media handling in `ChatView.vue` by replacing short media labels (`[img]` → `[image]`), tracking per-media status via `mediaStatus`, adding `onMediaLoad`/`onMediaError`, and rendering a loading spinner / error fallback while keeping the composer/footer locked and actions on one row with horizontal overflow. 
- Made group member list scrollable and softened the remove/leave affordance in `GroupView.vue`, and remove left groups from the UI immediately on leave. 

### Testing
- Installed dependencies with `yarn install` which completed successfully. 
- Started the dev server with `yarn dev --host 0.0.0.0 --port 5173` and the server came up successfully. 
- Ran a Playwright script that opened `/conversations` and produced a screenshot artifact at `artifacts/ui-conversations.png`, indicating the updated UI rendered without runtime errors. 
- No automated unit tests were added or run beyond the dev server and screenshot check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696181380c9c8331a49f257764c34007)