### PR TITLE
Enable conversation delete actions in Chat view sidebar

### DIFF
--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -21,10 +21,12 @@
             :fmt-time="convTime"
             :loading="convLoading"
             :error="convErr"
+            :show-delete="true"
             variant="split"
             empty-direct-text="No chats yet — start in Contacts 👋"
             empty-group-text="No groups yet — create one 👋"
             @select="selectConversation"
+            @delete="warnDelete"
           />
 
           <section class="chat-pane">
@@ -549,6 +551,7 @@ import {
   commentMessage,
   uncommentMessage,
   forwardMessage,
+  deleteConversation,
   isAbortError,
   ticksFor,
   titleForConversation,
@@ -983,6 +986,22 @@ function selectConversation(c) {
   if (!c || String(c.id) === convId.value) return
   emitConversationHydrate(c)
   router.replace({ name: 'chat', params: { type: c.type === 'group' ? 'group' : 'conv', id: c.id } })
+}
+
+async function warnDelete(c) {
+  if (!c) return
+  if (!confirm(`Delete chat:\n"${titleForConversation(c, meId.value)}"?`)) return
+  convErr.value = ''
+  try {
+    await deleteConversation(c.id)
+    window.dispatchEvent(
+      new CustomEvent('conversations:remove', {
+        detail: { conversationId: String(c.id || '') },
+      })
+    )
+  } catch (e) {
+    convErr.value = e?.response?.data?.message || e?.message || 'Failed to delete conversation'
+  }
 }
 
 // Sender resolution helpers to keep author data accurate per userId.


### PR DESCRIPTION
### Motivation
- The conversation list in the `/chat/...` sidebar lacked the hover delete affordance present on the `/conversations` page, causing inconsistent UX for removing chats.
- Deleting a conversation should behave the same from both the dedicated conversations view and the chat sidebar.

### Description
- Enable the delete control in the chat sidebar by passing `:show-delete="true"` to `ConversationList` in `ChatView.vue`.
- Wire the list `@delete` event to a new `warnDelete` handler and import `deleteConversation` from `@/services/api`.
- Implement `warnDelete` to confirm the action, call `deleteConversation(c.id)`, and emit a `conversations:remove` `CustomEvent` on success or set `convErr` on failure.

### Testing
- Ran `yarn install` in `webui` which completed successfully. 
- Started the dev server with `yarn dev` and the Vite server reported readiness. 
- Performed an automated browser run that loaded `http://127.0.0.1:5173/chat/1` and produced a screenshot of the chat sidebar, confirming the UI renders with delete controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d866f51c833189294d562c6867e0)