### PR TITLE
Align API responses with OpenAPI: include success messages and JSON body for deletion

### DIFF
--- a/service/api/conversation.go
+++ b/service/api/conversation.go
@@ -141,7 +141,8 @@ func (rt *_router) getMyConversations(
 
 	// OpenAPI: {code, data:{items:[]}}
 	resp := map[string]interface{}{
-		"code": http.StatusOK,
+		"code":    http.StatusOK,
+		"message": "Conversations list retrieved successfully",
 		"data": map[string]interface{}{
 			"items": convs,
 		},
@@ -192,5 +193,9 @@ func (rt *_router) deleteConversation(
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	resp := map[string]interface{}{
+		"code":    http.StatusOK,
+		"message": "Conversation deleted successfully",
+	}
+	_ = writeJSON(w, http.StatusOK, resp)
 }

--- a/service/api/messages.go
+++ b/service/api/messages.go
@@ -338,7 +338,8 @@ func (rt *_router) getMessageByID(
 	}
 
 	resp := map[string]interface{}{
-		"code": http.StatusOK,
+		"code":    http.StatusOK,
+		"message": "Message details retrieved",
 		"data": map[string]interface{}{
 			"resource": dto,
 		},


### PR DESCRIPTION
### Motivation

- Ensure responses delivered by the backend exactly match the OpenAPI spec envelopes for success responses.
- The spec requires a `message` field in success envelopes and a JSON body for the conversation deletion endpoint instead of an empty 204.
- Keep frontend and API contract consistent so clients always receive `{ code, message, data? }` shapes.

### Description

- Updated `getMyConversations` in `service/api/conversation.go` to include the OpenAPI `message` field in the response envelope.
- Changed `deleteConversation` in `service/api/conversation.go` to return a JSON success envelope (`code` + `message`) instead of `204 No Content`.
- Added the OpenAPI `message` field to the `getMessageByID` response in `service/api/messages.go` so the message detail envelope matches the spec.

### Testing

- No automated tests were executed for this change.
- Changes were compiled and committed as source edits to `service/api/conversation.go` and `service/api/messages.go`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d99d25f0833195680965375a7459)