### PR TITLE
Make conversation "Delete" leave group instead of deleting

### DIFF
--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -482,6 +482,18 @@ export async function getGroupDetail(id) {
   return unwrap(await get(`/groups/${encodeURIComponent(String(id))}`))
 }
 
+export async function getGroupIdForConversation(conversationId) {
+  const id = String(conversationId || '').trim()
+  if (!id) return ''
+  const list = await getGroupsList()
+  const arr = Array.isArray(list) ? list : (list?.items ?? list?.groups ?? list?.list ?? [])
+  const hit = (arr || []).find(
+    g => String(g?.conversationId ?? g?.conversation_id ?? '') === id
+  )
+  if (!hit) return ''
+  return String(hit.id ?? hit.group_id ?? hit._id ?? '')
+}
+
 export async function setGroupName(id, name) {
   return unwrap(await put(`/groups/${encodeURIComponent(String(id))}/name`, { name }))
 }
@@ -701,6 +713,7 @@ const api = {
   createGroup,
   getGroupsList,
   getGroupDetail,
+  getGroupIdForConversation,
   setGroupName,
   setGroupPhoto,
   addToGroup,

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -542,6 +542,7 @@ import {
   addToGroup,
   removeFromGroup,
   leaveGroup,
+  getGroupIdForConversation,
   sendMessage,
   sendImageMessage,
   startConversation,
@@ -990,6 +991,23 @@ function selectConversation(c) {
 
 async function warnDelete(c) {
   if (!c) return
+  if (c.type === 'group') {
+    convErr.value = ''
+    try {
+      const groupId =
+        c.groupId || c.group_id || c?.group?.id || (await getGroupIdForConversation(c.id))
+      if (!groupId) throw new Error('Group not found')
+      await leaveGroup(groupId)
+      window.dispatchEvent(
+        new CustomEvent('conversations:remove', {
+          detail: { conversationId: String(c.id || '') },
+        })
+      )
+    } catch (e) {
+      convErr.value = e?.response?.data?.message || e?.message || 'Failed to leave group'
+    }
+    return
+  }
   if (!confirm(`Delete chat:\n"${titleForConversation(c, meId.value)}"?`)) return
   convErr.value = ''
   try {

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -68,7 +68,16 @@ import { useRouter } from 'vue-router'
 import ErrorMsg from '@/components/ErrorMsg.vue'
 import ConversationList from '@/components/ConversationList.vue'
 
-import { getMyConversations, getAvatarUrl, deleteConversation, preferredDisplayName, initialsFor, normalizeUser } from '@/services/api'
+import {
+  getMyConversations,
+  getAvatarUrl,
+  deleteConversation,
+  leaveGroup,
+  getGroupIdForConversation,
+  preferredDisplayName,
+  initialsFor,
+  normalizeUser,
+} from '@/services/api'
 import { hydrateConversationList, removeConversation, upsertConversationMeta } from '@/services/conversationStore'
 import { ensureAuthReady, isAuthenticated, currentUser } from '@/services/auth'
 
@@ -299,6 +308,28 @@ function open(c) {
 
 // Remove a conversation after user confirmation.
 async function warnDelete(c) {
+  if (!c) return
+  if (c.type === 'group') {
+    err.value = ''
+    try {
+      const groupId =
+        c.groupId || c.group_id || c?.group?.id || (await getGroupIdForConversation(c.id))
+      if (!groupId) throw new Error('Group not found')
+      await leaveGroup(groupId)
+      const targetId = String(c.id || '')
+      convs.value = convs.value.filter(conv => String(conv.id) !== targetId)
+      removeConversation(targetId)
+      if (selectedId.value === targetId) selectedId.value = ''
+      window.dispatchEvent(
+        new CustomEvent('conversations:remove', {
+          detail: { conversationId: targetId },
+        })
+      )
+    } catch (e) {
+      err.value = e?.response?.data?.message || e?.message || 'Failed to leave group'
+    }
+    return
+  }
   if (!confirm(`Delete chat:\n"${displayName(c)}"?`)) return
   try {
     await deleteConversation(c.id)


### PR DESCRIPTION
### Motivation
- Map the UI "Delete" action for group conversations to a leave operation so the group is not deleted and only the current user is removed. 
- Ensure the local conversation list and store update immediately when the user leaves a group so the group disappears from the UI. 
- Provide a helper to resolve a `conversationId` back to the owning `groupId` so leave operations can be performed from conversation-context views. 

### Description
- Add `getGroupIdForConversation(conversationId)` to `webui/src/services/api.js` to look up a group by its `conversationId`. 
- Update `ConversationsView.vue` to call `leaveGroup(groupId)` for group items, remove the conversation from `convs` and the conversation store, and dispatch `conversations:remove`. 
- Update `ChatView.vue` to route group delete actions to `leaveGroup` and dispatch `conversations:remove` instead of deleting the conversation. 
- Preserve the existing delete/confirmation flow for non-group conversations and keep imports and API surface updated to include the new helper. 

### Testing
- No automated tests were executed for this change. 
- The change is limited to client-side UI behavior and API helper addition, and the runtime code paths were updated to remove group convs from local state after leaving.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e10c10408331a7578c95267185a6)