### PR TITLE
Align OpenAPI path params with backend routes

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -926,7 +926,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
   
-  /conversations/{id}:
+  /conversations/:id:
     parameters:
       - $ref: '#/components/parameters/id'
     delete:
@@ -1134,7 +1134,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /users/{userId}/profile:
+  /users/:userId/profile:
     parameters:
       - $ref: '#/components/parameters/userId'
     get:
@@ -1244,7 +1244,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /groups/{id}:
+  /groups/:id:
     parameters:
       - $ref: '#/components/parameters/id'
     get:
@@ -1276,7 +1276,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /groups/{id}/name:
+  /groups/:id/name:
     parameters:
       - $ref: '#/components/parameters/id'
     put:
@@ -1303,7 +1303,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /groups/{id}/photo:
+  /groups/:id/photo:
     parameters:
       - $ref: '#/components/parameters/id'
     put:
@@ -1349,7 +1349,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /groups/{id}/members:
+  /groups/:id/members:
     parameters:
       - $ref: '#/components/parameters/id'
     post:
@@ -1592,7 +1592,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         
-  /messages/{id}:
+  /messages/:id:
     parameters:
       - $ref: '#/components/parameters/id'
     get:
@@ -1645,7 +1645,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /messages/{id}/forwards:
+  /messages/:id/forwards:
     parameters:
       - $ref: '#/components/parameters/id'
     post:
@@ -1675,7 +1675,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /messages/{id}/comment:
+  /messages/:id/comment:
     parameters:
       - $ref: '#/components/parameters/id'
     post:


### PR DESCRIPTION
### Motivation
- Make the OpenAPI documentation use the same path-parameter syntax as the backend route registration (colon-prefixed params) to avoid mismatches between doc and runtime routes.

### Description
- Updated `doc/api.yaml` to replace brace-style path params with colon-style params (e.g. `/conversations/{id}` -> `/conversations/:id`) for routes including conversations, users (profile), groups, and messages across the file.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680a56d34083318335558c9cf471ab)