### PR TITLE
Fix OpenAPI $ref sibling violations

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -184,8 +184,9 @@ components:
           required: [data]
           properties:
             data:
-              $ref: '#/components/schemas/User'
               description: The current user's profile details.
+              allOf:
+                - $ref: '#/components/schemas/User'
 
     UserEnvelopeCollection:
       description: Envelope with a list of users and optional pagination.
@@ -278,8 +279,9 @@ components:
           items:
             $ref: '#/components/schemas/User'
         lastMessage:
-          $ref: '#/components/schemas/Message'
           description: Most recent message in the conversation, if available.
+          allOf:
+            - $ref: '#/components/schemas/Message'
         updatedAt:
           type: string
           format: date-time


### PR DESCRIPTION
### Motivation
- Resolve Spectral `no-$ref-siblings` rule violations in the OpenAPI spec so linting can pass.

### Description
- Wrap the `#/components/schemas/User` reference used by `UserSelfEnvelope.data` in an `allOf` while preserving its description in `doc/api.yaml`.
- Wrap the `#/components/schemas/Message` reference used by `Conversation.properties.lastMessage` in an `allOf` while preserving its description in `doc/api.yaml`.

### Testing
- Ran `npx -y @stoplight/spectral-cli lint doc/api.yaml -r doc/spectral.yaml --format pretty -v` before changes which reported two `no-$ref-siblings` errors.
- No automated tests were run after applying the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696813e640f08331862138d981860e37)