### PR TITLE
Fix user profile route conflict

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -1158,7 +1158,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
-  /users/{userId}/profile:
+  /users/profile/{userId}:
     parameters:
       - $ref: '#/components/parameters/userId'
     get:

--- a/service/api/api-handler.go
+++ b/service/api/api-handler.go
@@ -47,8 +47,8 @@ func (rt *_router) RegisterRoutes() {
 	rt.router.PUT("/users/me/photo", rt.wrap(rt.setMyPhoto))
 	// GET /users/search -> searchUsers
 	rt.router.GET("/users/search", rt.wrap(rt.searchUsers))
-	// GET /users/{userId}/profile -> getUserProfile
-	rt.router.GET("/users/:userId/profile", rt.wrap(rt.getUserProfile))
+	// GET /users/profile/{userId} -> getUserProfile
+	rt.router.GET("/users/profile/:userId", rt.wrap(rt.getUserProfile))
 
 	// Groups
 	// POST /groups -> createGroup

--- a/service/api/users.go
+++ b/service/api/users.go
@@ -53,7 +53,7 @@ func (rt *_router) getUserInfo(
 	})
 }
 
-// getUserProfile handles GET /users/{userId}/profile and returns public profile
+// getUserProfile handles GET /users/profile/{userId} and returns public profile
 // data. A minimal query-key fallback is kept for older clients.
 func (rt *_router) getUserProfile(
 	w http.ResponseWriter,

--- a/webui/src/services/api.js
+++ b/webui/src/services/api.js
@@ -283,7 +283,7 @@ export async function getMyProfile() {
 export async function getUserProfile(userId) {
   const id = String(userId || '').trim()
   if (!id) throw new Error('userId required')
-  return unwrap(await get(`/users/${encodeURIComponent(id)}/profile`))
+  return unwrap(await get(`/users/profile/${encodeURIComponent(id)}`))
 }
 
 export async function setMyUserName(name) {


### PR DESCRIPTION
### Motivation
- Resolve a wildcard route conflict in the HTTP router where the existing pattern caused a panic when registering `/users/:userId/profile` alongside other `/users/...` children.
- Ensure the backend route, OpenAPI spec, and web UI client use a non-conflicting path for retrieving user profiles.

### Description
- Change the backend route registration to `rt.router.GET("/users/profile/:userId", rt.wrap(rt.getUserProfile))` in `service/api/api-handler.go`.
- Update the handler comment in `service/api/users.go` to reflect the new path `GET /users/profile/{userId}`.
- Update the web UI API client call in `webui/src/services/api.js` to request `/users/profile/{userId}`.
- Update the OpenAPI document `doc/api.yaml` to declare the path `/users/profile/{userId}`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696814d7bdf48331921fe36be29f31ad)