### PR TITLE
Fix chat layout scrolling at high zoom

### DIFF
--- a/webui/src/assets/main.css
+++ b/webui/src/assets/main.css
@@ -33,7 +33,14 @@
 }
 
 *{ box-sizing: border-box; }
-html,body,#app{ height:100%; }
+html,
+body {
+  height: 100%;
+  overflow-y: auto;
+}
+#app {
+  min-height: 100%;
+}
 body{
   margin:0;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -30,7 +30,7 @@
           />
 
           <section class="chat-pane">
-            <div class="chat-pane__body">
+            <div class="chat-pane__body chat-column">
               <header v-if="convId && !notFound" class="chat-header">
                 <div class="chat-header__left">
                   <span
@@ -68,7 +68,7 @@
               <div
                 v-else
                 ref="scrollbox"
-                class="scroll"
+                class="scroll chat-messages"
                 @scroll="handleScroll"
               >
                 <template v-if="messages.length">
@@ -261,7 +261,7 @@
               </div>
 
               <!-- ===== COMPOSER ===== -->
-              <div v-if="convId && !notFound" class="composer">
+              <div v-if="convId && !notFound" class="composer chat-input">
                 <div v-if="replyTarget" class="reply-banner">
                   Replying to
                   {{ nameForSender(replyTarget.senderId, replyTarget) || 'message' }}
@@ -2210,7 +2210,7 @@ watch(convId, async () => {
   --avatar-text: #0f766e;
   --panel-pad: 16px;
   min-height: 100vh;
-  height: 100vh;
+  height: auto;
   width: 100%;
   min-width: 0;
   flex: 1 1 auto;
@@ -2285,7 +2285,7 @@ watch(convId, async () => {
   flex-direction: column;
   min-height: 0;
   padding: 16px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .content-inner {
@@ -2304,7 +2304,7 @@ watch(convId, async () => {
   flex-direction: row;
   background: var(--panel);
   border: 1px solid var(--border);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .chat-layout {
@@ -2313,6 +2313,7 @@ watch(convId, async () => {
   flex: 1 1 auto;
   min-height: 0;
   height: 100%;
+  overflow-y: auto;
 }
 
 .chat-layout.has-group {
@@ -2332,15 +2333,20 @@ watch(convId, async () => {
   min-height: 0;
   height: 100%;
   flex: 1 1 auto;
-  overflow: hidden;
+  overflow: visible;
 }
 
-.chat-pane__body {
+.chat-pane__body,
+.chat-column {
   display: flex;
   flex-direction: column;
   min-height: 0;
   flex: 1 1 auto;
-  overflow: hidden;
+  overflow: visible;
+}
+
+.chat-column {
+  min-height: 100%;
 }
 
 .group-panel {
@@ -2654,7 +2660,8 @@ watch(convId, async () => {
 }
 
 
-.scroll {
+.scroll,
+.chat-messages {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
@@ -3102,7 +3109,8 @@ img.member-avatar {
   color: #475569;
 }
 
-.composer {
+.composer,
+.chat-input {
   margin-top: 12px;
   flex: 0 0 auto;
   flex-shrink: 0;


### PR DESCRIPTION
### Motivation
- Prevent the chat input from being pushed out of the viewport at high browser zoom or after window resize by allowing the document to scroll and by avoiding fixed 100vh height locks in layout containers.
- Ensure the chat column uses vertical flex layout so the messages region can shrink/scroll and the composer remains reachable.
- Remove hidden overflow on main layout wrappers so vertical scrolling always works when content becomes taller than the viewport.

### Description
- Allow document-level vertical scrolling by setting `html, body { height: 100%; overflow-y: auto; }` and making `#app` use `min-height: 100%;` in `webui/src/assets/main.css`.
- Stop locking the top-level page to `100vh` by changing `.page` from `height: 100vh` to `height: auto` in `webui/src/views/ChatView.vue`.
- Introduce proper flex column semantics for the chat area by marking the chat body as a `.chat-column`, making the message area `.chat-messages` with `flex: 1` and `overflow-y: auto`, and marking the composer as `.chat-input` with `flex-shrink: 0` in `webui/src/views/ChatView.vue`.
- Remove `overflow: hidden` from the main wrappers (`.workspace`, `.panel`, `.chat-pane`, and `.chat-pane__body`) and enable `overflow-y: auto` on `.chat-layout` so the page can scroll when content grows.
- Files changed: `webui/src/assets/main.css` and `webui/src/views/ChatView.vue`.

CSS diff (relevant hunks):
```diff
*** webui/src/assets/main.css
@@
-*{ box-sizing: border-box; }
-html,body,#app{ height:100%; }
+*{ box-sizing: border-box; }
+html,
+body {
+  height: 100%;
+  overflow-y: auto;
+}
+#app {
+  min-height: 100%;
+}
*** webui/src/views/ChatView.vue (style section)
@@
-.page { min-height: 100vh; height: 100vh; }
+.page { min-height: 100vh; height: auto; }
@@
-.workspace { ... overflow: hidden; }
+.workspace { ... overflow: visible; }
@@
-.panel { ... overflow: hidden; }
+.panel { ... overflow: visible; }
@@
-.chat-layout { ... height: 100%; }
+.chat-layout { ... height: 100%; overflow-y: auto; }
@@
-.chat-pane { ... overflow: hidden; }
+.chat-pane { ... overflow: visible; }
@@
-.chat-pane__body { display:flex; flex-direction:column; min-height:0; flex:1 1 auto; overflow: hidden; }
+.chat-pane__body,
+.chat-column { display:flex; flex-direction:column; min-height:0; flex:1 1 auto; overflow: visible; }
+
+.chat-column { min-height: 100%; }
@@
-.scroll { flex:1 1 auto; min-height:0; overflow-y:auto; padding: 10px 12px 88px; }
+.scroll, .chat-messages { flex:1 1 auto; min-height:0; overflow-y:auto; padding: 10px 12px 88px; }
@@
-.composer { margin-top:12px; flex:0 0 auto; flex-shrink:0; ... position: sticky; bottom:0; }
+.composer, .chat-input { margin-top:12px; flex:0 0 auto; flex-shrink:0; ... position: sticky; bottom:0; }
```

### Testing
- No automated tests were executed for this change (no CI/test run was performed).
- The change is layout-only (CSS and template class additions) and does not modify JavaScript logic or event handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968176c713c83318bbf0c55d50036e0)