### PR TITLE
Fix chat layout so composer stays fixed and only messages scroll

### DIFF
--- a/webui/src/assets/main.css
+++ b/webui/src/assets/main.css
@@ -36,10 +36,13 @@
 html,
 body {
   height: 100%;
-  overflow-y: auto;
+  margin: 0;
+  overflow: hidden;
 }
 #app {
-  min-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 body{
   margin:0;

--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -2312,8 +2312,7 @@ watch(convId, async () => {
   align-items: stretch;
   flex: 1 1 auto;
   min-height: 0;
-  height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .chat-layout.has-group {
@@ -2342,11 +2341,12 @@ watch(convId, async () => {
   flex-direction: column;
   min-height: 0;
   flex: 1 1 auto;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .chat-column {
-  min-height: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .group-panel {
@@ -3121,8 +3121,6 @@ img.member-avatar {
   background: white;
   border-radius: 0;
   border: 1px solid #e1e5eb;
-  position: sticky;
-  bottom: 0;
 }
 
 .attach-preview {


### PR DESCRIPTION
### Motivation
- Ensure the message input (composer) remains visible and pinned to the bottom of the chat view at all zoom levels so the page never has to scroll to reach the input. 
- Constrain scrolling to the message list only, preventing the entire page or chat column from scrolling and avoiding `100vh` usage.

### Description
- Disable page-level scrolling and reset margins by updating `html, body` to `height: 100%; margin: 0; overflow: hidden` in `webui/src/assets/main.css` and make `#app` a full-height flex column with `height: 100%; display: flex; flex-direction: column;`.
- Make the chat layout and column non-scrolling flex containers by changing `.chat-layout`, `.chat-pane__body`, and `.chat-column` to use `overflow: hidden` and set `.chat-column { height: 100%; }` in `webui/src/views/ChatView.vue`.
- Stop using sticky positioning for the composer by removing `position: sticky; bottom: 0;` from `.composer, .chat-input` so the composer is fixed by the flex layout and will remain at the bottom of the chat column.
- Keep the messages list as the only scrollable area (existing `.chat-messages`/`.scroll` rules already provide `flex: 1 1 auto; min-height: 0; overflow-y: auto;`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968198df08c8331bbbd85d9dfb0b708)