### PR TITLE
Fix chat layout scrolling behavior

### DIFF
--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -2209,8 +2209,8 @@ watch(convId, async () => {
   --avatar-border: #a7f3d0;
   --avatar-text: #0f766e;
   --panel-pad: 16px;
-  min-height: 100vh;
-  height: auto;
+  height: 100%;
+  min-height: 0;
   width: 100%;
   min-width: 0;
   flex: 1 1 auto;
@@ -2218,6 +2218,7 @@ watch(convId, async () => {
   flex-direction: column;
   background: #e5e7eb;
   color: #1f2937;
+  overflow: hidden;
 }
 
 .chat-header {
@@ -2285,7 +2286,7 @@ watch(convId, async () => {
   flex-direction: column;
   min-height: 0;
   padding: 16px;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .content-inner {
@@ -2295,6 +2296,7 @@ watch(convId, async () => {
   gap: 12px;
   flex: 1 1 auto;
   min-height: 0;
+  overflow: hidden;
 }
 
 .panel {
@@ -2304,7 +2306,7 @@ watch(convId, async () => {
   flex-direction: row;
   background: var(--panel);
   border: 1px solid var(--border);
-  overflow: visible;
+  overflow: hidden;
 }
 
 .chat-layout {
@@ -2332,7 +2334,7 @@ watch(convId, async () => {
   min-height: 0;
   height: 100%;
   flex: 1 1 auto;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .chat-pane__body,
@@ -2667,7 +2669,7 @@ watch(convId, async () => {
   overflow-y: auto;
   background: transparent;
   border-radius: 0;
-  padding: 10px 12px 88px;
+  padding: 10px 12px 16px;
 }
 
 .empty-thread {


### PR DESCRIPTION
### Motivation
- Prevent the overall page from scrolling and ensure the message list is the only scrollable area so the composer remains visible at the bottom. 
- Avoid the chat pane growing and pushing the input up when new messages arrive or when the window is resized.

### Description
- Constrained top-level chat containers by switching `.page` to `height: 100%` and `min-height: 0` and adding `overflow: hidden` so the page cannot scroll. 
- Set `overflow: hidden` on `.workspace`, `.content-inner`, `.panel`, and `.chat-pane` to keep layout height constrained and avoid parent containers being pushed by `.chat-messages`.
- Ensure the chat column remains a fixed-height flex column (`.chat-column` / `.chat-pane__body`) with `overflow: hidden` so only `.chat-messages` scrolls. 
- Reduced bottom padding on `.scroll, .chat-messages` from `88px` to `16px` now that the composer is fixed within the column.

### Testing
- Started the dev server with `yarn --cwd webui dev` and confirmed the app served successfully. 
- Ran a Playwright script that navigated to `http://127.0.0.1:4173/`, captured `artifacts/chat-layout.png`, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696898eae79c8331aa6c3d52fe3b8d02)