### PR TITLE
Make chat composer sticky to bottom of chat pane

### DIFF
--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -3113,7 +3113,7 @@ img.member-avatar {
 
 .composer,
 .chat-input {
-  margin-top: 12px;
+  margin-top: auto;
   flex: 0 0 auto;
   flex-shrink: 0;
   display: flex;
@@ -3123,6 +3123,9 @@ img.member-avatar {
   background: white;
   border-radius: 0;
   border: 1px solid #e1e5eb;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
 }
 
 .attach-preview {


### PR DESCRIPTION
### Motivation
- Ensure the message composer remains anchored at the bottom of the chat pane so it stays visible as messages grow or when the page is resized.

### Description
- Adjust CSS in `webui/src/views/ChatView.vue` by changing `.composer, .chat-input` to `margin-top: auto` and adding `position: sticky`, `bottom: 0`, and `z-index: 1` so the composer is pinned to the bottom of the chat column.

### Testing
- Started the frontend dev server with `npm --prefix webui run dev` and captured a Playwright screenshot of the chat page, which shows the composer pinned to the bottom (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69689b1fa5f88331a622cb9d5def3275)