### PR TITLE
Fix chat composer bottom alignment

### DIFF
--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -2285,7 +2285,7 @@ watch(convId, async () => {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  padding: 16px;
+  padding: 16px 16px 0;
   overflow: hidden;
 }
 
@@ -2325,7 +2325,7 @@ watch(convId, async () => {
   background: var(--panel);
   border-left: 1px solid var(--border);
   border-radius: 0;
-  padding: 24px;
+  padding: 24px 24px 0;
   display: flex;
   flex-direction: column;
   gap: 3px;


### PR DESCRIPTION
### Motivation
- Keep the message composer anchored to the bottom edge of the chat pane so the input area does not sit too high and remains fixed during scrolling and viewport resizing.

### Description
- Adjust CSS in `webui/src/views/ChatView.vue` by removing bottom padding on `.workspace` and `.chat-pane` (changed `padding: 16px;` → `padding: 16px 16px 0;` and `padding: 24px;` → `padding: 24px 24px 0;`) so the sticky composer (`.composer` / `.chat-input`) sits flush at the bottom.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which started successfully, and
- Ran a Playwright script that loaded `/#/chat/conv/1` and captured a screenshot which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69689e15a778833180a8d2b566f5ef0a)