### PR TITLE
Standardize file header comments and add related-file references

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -16,6 +16,10 @@ Exit codes:
 
 0   HTTP 200/204 received
 >0  connection error or unexpected status code
+
+Related files:
+- cmd/webapi/main.go (hosts the /liveness endpoint)
+- service/api/liveness.go (handler implementation)
 */
 package main
 
@@ -26,6 +30,7 @@ import (
 	"os"
 )
 
+// main runs the CLI healthcheck probe against the API server.
 func main() {
 	port := flag.Int("port", 3000, "HTTP port for healthcheck")
 

--- a/cmd/webapi/cors.go
+++ b/cmd/webapi/cors.go
@@ -1,5 +1,6 @@
 // cors.go centralizes the CORS middleware used by the web API server to make
 // cross-origin requests predictable for browsers and API clients.
+// Related files: cmd/webapi/main.go, service/api/api.go.
 package main
 
 import (

--- a/cmd/webapi/load-configuration.go
+++ b/cmd/webapi/load-configuration.go
@@ -1,6 +1,7 @@
 // load-configuration.go defines the configuration structures and helpers used
 // to assemble runtime settings for the web API server from CLI flags,
 // environment variables, and optional YAML overlays.
+// Related files: cmd/webapi/main.go, README.md, doc/*.
 package main
 
 import (

--- a/cmd/webapi/main.go
+++ b/cmd/webapi/main.go
@@ -17,6 +17,15 @@ Exit codes:
 
 The program migrates the embedded database schema to the latest version on
 startup before accepting requests.
+
+Related files:
+- cmd/webapi/load-configuration.go (configuration loading)
+- cmd/webapi/cors.go (CORS middleware)
+- cmd/webapi/register-web-ui.go (web UI mounting, webui build tag)
+- cmd/webapi/register-web-ui-stub.go (web UI stub, non-webui builds)
+- service/api/api.go (API router)
+- service/database/app_database.go (database initialization)
+- webui/register_webui.go (embedded static handler)
 */
 package main
 
@@ -181,7 +190,7 @@ func run() error {
 		// 	return fmt.Errorf("could not stop server gracefully: %w", err)
 		// }
 
-		//// a fix because I'm using windows
+		// Windows-friendly shutdown mapping.
 		switch {
 		case sig == syscall.SIGTERM || sig == os.Interrupt:
 			return errors.New("received shutdown signal")

--- a/cmd/webapi/register-web-ui-stub.go
+++ b/cmd/webapi/register-web-ui-stub.go
@@ -2,6 +2,7 @@
 
 // register-web-ui-stub.go provides a no-op placeholder when the binary is
 // compiled without the `webui` build tag, leaving routing untouched.
+// Related files: cmd/webapi/register-web-ui.go, webui/register_webui.go.
 package main
 
 import (

--- a/cmd/webapi/register-web-ui.go
+++ b/cmd/webapi/register-web-ui.go
@@ -3,6 +3,7 @@
 // register-web-ui.go mounts the compiled frontend assets when the binary is
 // built with the `webui` tag, while forwarding API paths to the existing API
 // handler.
+// Related files: cmd/webapi/register-web-ui-stub.go, webui/register_webui.go.
 package main
 
 import (

--- a/service/api/api-context-wrapper.go
+++ b/service/api/api-context-wrapper.go
@@ -1,5 +1,6 @@
 // api-context-wrapper.go enriches httprouter handlers with request metadata and
 // authentication details so business handlers receive consistent context.
+// Related files: service/reqcontext/request-context.go, service/api/api.go.
 package api
 
 import (

--- a/service/api/api-handler.go
+++ b/service/api/api-handler.go
@@ -1,5 +1,6 @@
 // api-handler.go centralizes route registration so OpenAPI endpoints stay
 // consistent and easy to audit in one place.
+// Related files: service/api/api.go, service/api/*, cmd/webapi/main.go.
 package api
 
 import (

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -1,5 +1,6 @@
 // api.go constructs the HTTP router for the service API and centralizes shared
 // dependencies such as logging and database connectivity.
+// Related files: service/api/api-handler.go, service/api/api-context-wrapper.go, service/database/app_database.go.
 package api
 
 import (

--- a/service/api/auth_do_login.go
+++ b/service/api/auth_do_login.go
@@ -1,6 +1,7 @@
 // auth_do_login.go implements the session login endpoint and its response
 // envelope to match the OpenAPI user/token contract. Authentication is based on
 // a display name and returns a token equal to the user ID for simplicity.
+// Related files: service/api/api-handler.go, service/database/user_database_methods.go.
 package api
 
 import (
@@ -33,6 +34,7 @@ type authEnvelope struct {
 	} `json:"data"`
 }
 
+// toAPIUser maps a database user model into the API response shape.
 func toAPIUser(u models.User) apiUser {
 	return apiUser{
 		ID:        u.ID,

--- a/service/api/context-utils.go
+++ b/service/api/context-utils.go
@@ -1,5 +1,6 @@
 // context-utils.go centralizes JSON helpers for decoding request payloads and
 // sending structured responses and error envelopes.
+// Related files: service/api/api-context-wrapper.go, service/api/api.go.
 package api
 
 import (

--- a/service/api/conversation.go
+++ b/service/api/conversation.go
@@ -1,6 +1,7 @@
 // conversation.go hosts the conversation creation endpoints, validating names
 // and member lists, normalizing identifiers, and delegating persistence while
 // keeping responses aligned with the OpenAPI contract.
+// Related files: service/api/api-handler.go, service/database/conversation_start.go.
 package api
 
 import (
@@ -150,6 +151,8 @@ func (rt *_router) getMyConversations(
 	_ = writeJSON(w, http.StatusOK, resp)
 }
 
+// deleteConversation handles DELETE /conversations/{id} and removes the record
+// after verifying the caller is a member.
 func (rt *_router) deleteConversation(
 	w http.ResponseWriter,
 	r *http.Request,

--- a/service/api/groups.go
+++ b/service/api/groups.go
@@ -1,5 +1,6 @@
 // groups.go contains the group management endpoints, including creation,
 // membership updates, and media uploads while enforcing OpenAPI constraints.
+// Related files: service/api/api-handler.go, service/database/group_database_methods.go.
 package api
 
 import (

--- a/service/api/liveness.go
+++ b/service/api/liveness.go
@@ -1,5 +1,6 @@
 // liveness.go hosts minimal health probes used by load balancers and nginx
 // routing checks.
+// Related files: cmd/healthcheck/healthcheck.go, service/api/api-handler.go.
 package api
 
 import (

--- a/service/api/messages.go
+++ b/service/api/messages.go
@@ -1,5 +1,6 @@
 // messages.go serves message read/write endpoints and the DTO helpers that map
 // internal models to the OpenAPI JSON shapes.
+// Related files: service/api/api-handler.go, service/database/message_database_methods.go, service/api/upload_utils.go.
 package api
 
 import (
@@ -20,6 +21,7 @@ import (
 
 // Section: DTOs (match OpenAPI JSON shapes; keep models.* as internal)
 
+// MessageDTO represents the public-facing message shape used in JSON responses.
 type MessageDTO struct {
 	ID             string       `json:"id"`
 	Content        string       `json:"content"`
@@ -104,7 +106,9 @@ func parseLimit(raw string, dflt, min, max int) int {
 
 // timeBefore reports a < b assuming RFC3339 timestamps (lex compare is OK for full RFC3339Z).
 func timeBefore(a, b string) bool { return a < b }
-func timeAfter(a, b string) bool  { return a > b }
+
+// timeAfter reports a > b using the same RFC3339-safe comparison as timeBefore.
+func timeAfter(a, b string) bool { return a > b }
 
 // Endpoint: POST /messages -> sendMessage (OpenAPI)
 

--- a/service/api/shutdown.go
+++ b/service/api/shutdown.go
@@ -1,5 +1,6 @@
 // shutdown.go provides a dev-only POST /shutdown hook so integration tests can
 // stop the server gracefully without resorting to process signals.
+// Related files: service/api/api-handler.go, cmd/webapi/main.go.
 //go:build dev
 
 package api

--- a/service/api/upload_utils.go
+++ b/service/api/upload_utils.go
@@ -1,5 +1,6 @@
 // upload_utils.go centralizes helpers for sanitizing upload paths and
 // validating basic file properties before persisting user-supplied content.
+// Related files: service/api/messages.go, service/api/groups.go.
 package api
 
 import (

--- a/service/api/users.go
+++ b/service/api/users.go
@@ -1,5 +1,6 @@
 // users.go exposes user profile endpoints, covering display name updates, photo
 // uploads, user search, and profile retrieval per the OpenAPI spec.
+// Related files: service/api/api-handler.go, service/database/user_database_methods.go.
 package api
 
 import (
@@ -146,7 +147,6 @@ func (rt *_router) setMyUserName(
 // setUserPhoto handles PUT /users/me/photo for avatar updates.
 // It supports preset query parameters or multipart uploads and returns a
 // FileUploadEnvelope: data.file { filename, uri, size? }.
-
 func (rt *_router) setUserPhoto(
 	w http.ResponseWriter,
 	r *http.Request,

--- a/service/database/app_database.go
+++ b/service/database/app_database.go
@@ -1,3 +1,6 @@
+// app_database.go defines the database interface and initializes the SQLite
+// schema used by the service.
+// Related files: service/database/*_methods.go, service/models/models.go, service/api/api.go.
 package database
 
 import (
@@ -89,6 +92,7 @@ func New(db *sql.DB) (*appdbimpl, error) {
 	return &appdbimpl{c: db}, nil
 }
 
+// initializeTables creates or updates core tables and index definitions.
 func initializeTables(db *sql.DB) error {
 	_, err := db.Exec(`
 		PRAGMA foreign_keys = ON;

--- a/service/database/conversation_start.go
+++ b/service/database/conversation_start.go
@@ -1,4 +1,5 @@
-// file: service/database/conversation_database_methods.go
+// conversation_start.go implements conversation creation and hydration helpers.
+// Related files: service/api/conversation.go, service/models/models.go.
 package database
 
 import (

--- a/service/database/group_database_methods.go
+++ b/service/database/group_database_methods.go
@@ -1,3 +1,5 @@
+// group_database_methods.go implements group persistence and member lookups.
+// Related files: service/api/groups.go, service/models/models.go.
 package database
 
 import (

--- a/service/database/message_database_methods.go
+++ b/service/database/message_database_methods.go
@@ -1,3 +1,6 @@
+// message_database_methods.go contains message persistence and retrieval logic
+// for conversations, private messages, and comments.
+// Related files: service/api/messages.go, service/models/models.go.
 package database
 
 import (

--- a/service/database/user_database_methods.go
+++ b/service/database/user_database_methods.go
@@ -1,5 +1,5 @@
-// file: service/database/user_database_methods.go
-// comment
+// user_database_methods.go implements user CRUD and search queries.
+// Related files: service/api/users.go, service/models/models.go.
 package database
 
 import (
@@ -37,6 +37,7 @@ func (db *appdbimpl) CreateUser(u models.User) (models.User, error) {
 	return db.GetUserByID(u.ID)
 }
 
+// GetUser resolves a user by ID and mirrors GetUserByID for compatibility.
 func (db *appdbimpl) GetUser(userID string) (models.User, error) {
 	return db.GetUserByID(userID)
 }

--- a/service/globaltime/globaltime.go
+++ b/service/globaltime/globaltime.go
@@ -1,3 +1,6 @@
+// globaltime.go provides a controllable clock for tests and time-dependent
+// behavior throughout the service.
+// Related files: service/api/messages.go, service/database/*.go.
 package globaltime
 
 import "time"

--- a/service/models/models.go
+++ b/service/models/models.go
@@ -1,3 +1,6 @@
+// models.go defines API-facing data structures shared between handlers and
+// database layers.
+// Related files: service/api/*.go, service/database/*.go.
 package models
 
 // User represents the minimal public profile returned by the API.

--- a/service/reqcontext/request-context.go
+++ b/service/reqcontext/request-context.go
@@ -1,6 +1,7 @@
 // Package reqcontext defines the per-request context populated by the
 // middleware in api-context-wrapper.go. Each field should be treated as
 // request-scoped unless explicitly documented otherwise.
+// Related files: service/api/api-context-wrapper.go, service/api/api.go.
 package reqcontext
 
 import (

--- a/webui/register_webui.go
+++ b/webui/register_webui.go
@@ -1,3 +1,6 @@
+// register_webui.go serves embedded frontend assets and provides SPA fallback
+// routing for client-side routes.
+// Related files: webui/static-resources.go, webui/static-resources_stub.go, cmd/webapi/register-web-ui.go.
 package webui
 
 import (

--- a/webui/static-resources.go
+++ b/webui/static-resources.go
@@ -1,6 +1,8 @@
 //go:build webui
 // +build webui
 
+// static-resources.go embeds the built frontend assets for webui builds.
+// Related files: webui/register_webui.go, webui/static-resources_stub.go.
 package webui
 
 import "embed"

--- a/webui/static-resources_stub.go
+++ b/webui/static-resources_stub.go
@@ -1,6 +1,9 @@
 //go:build !webui
 // +build !webui
 
+// static-resources_stub.go provides the empty embed used when the webui build
+// tag is not enabled.
+// Related files: webui/static-resources.go, webui/register_webui.go.
 package webui
 
 import "embed"


### PR DESCRIPTION
### Motivation

- Unify and clarify file-level comments across the repository so headers are simple, consistent, and English-only.
- Make it easier to navigate code by adding explicit `Related files` references at the top of modules that show key associations between packages.
- Remove some extra blank lines and add small clarifying comments to make code regions and helper purposes more explicit without changing behavior.

### Description

- Added concise file header comments and `Related files:` references to many Go files under `cmd/`, `service/`, and `webui/`, including `cmd/webapi/*`, `service/api/*`, `service/database/*`, `service/models/*`, and `webui/*`.
- Clarified a small number of helper comments (for example `toAPIUser`, DTOs, and time comparison helpers) and adjusted a Windows shutdown comment for clarity in `cmd/webapi/main.go`.
- Removed or consolidated extra blank lines in a few places and added short one-line function/file summaries where missing; no code logic or API behavior was changed.
- All edits are comment and formatting only; no runtime code semantics were modified.

### Testing

- No automated tests were run because this change only updates comments and whitespace; the change is comment-only and should not affect runtime behavior or test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f87d66e08331894c93148d7bbaa9)