### PR TITLE
Remove left groups from conversation lists

### DIFF
--- a/webui/src/views/ChatView.vue
+++ b/webui/src/views/ChatView.vue
@@ -842,6 +842,24 @@ function normalizeParticipantList(list = []) {
     .filter(u => u.id)
 }
 
+function matchesConversationId(conversation = {}, targetId = '') {
+  const target = String(targetId || '')
+  if (!target) return false
+  const conversationId = String(
+    conversation?.id ||
+      conversation?.conversationId ||
+      conversation?.conversation_id ||
+      ''
+  )
+  const groupId = String(
+    conversation?.groupId ||
+      conversation?.group_id ||
+      conversation?.group?.id ||
+      ''
+  )
+  return target === conversationId || (groupId && target === groupId)
+}
+
 async function loadConversationList() {
   convErr.value = ''
   await ensureAuthReady()
@@ -954,8 +972,24 @@ function handleConversationRemove(e) {
   const detail = e?.detail || {}
   const targetId = detail.conversationId ? String(detail.conversationId) : ''
   if (!targetId) return
-  convList.value = convList.value.filter(c => String(c.id) !== targetId)
-  removeConversation(targetId)
+  const matched = convList.value.filter(c => matchesConversationId(c, targetId))
+  convList.value = convList.value.filter(c => !matchesConversationId(c, targetId))
+  const idsToRemove = new Set([targetId])
+  matched.forEach(c => {
+    const candidateIds = [
+      c?.id,
+      c?.conversationId,
+      c?.conversation_id,
+      c?.groupId,
+      c?.group_id,
+      c?.group?.id,
+    ]
+    candidateIds.forEach(id => {
+      const key = String(id || '')
+      if (key) idsToRemove.add(key)
+    })
+  })
+  idsToRemove.forEach(id => removeConversation(id))
 
   if (String(convId.value || '') === targetId) {
     resetChatState()
@@ -2031,14 +2065,30 @@ async function onLeaveGroup() {
   groupNotice.value = ''
   try {
     await leaveGroup(groupId.value)
-    if (convId.value) {
-      convList.value = convList.value.filter(c => String(c.id) !== convId.value)
-      removeConversation(convId.value)
-      window.dispatchEvent(
-        new CustomEvent('conversations:remove', {
-          detail: { conversationId: convId.value },
-        })
+    const removalIds = new Set([
+      convId.value,
+      groupId.value,
+      currentConv.value?.id,
+      currentConv.value?.conversationId,
+      currentConv.value?.conversation_id,
+      currentConv.value?.groupId,
+      currentConv.value?.group_id,
+      currentConv.value?.group?.id,
+    ])
+    removalIds.delete('')
+    const idsToRemove = Array.from(removalIds).filter(Boolean).map(id => String(id))
+    if (idsToRemove.length) {
+      convList.value = convList.value.filter(
+        c => !idsToRemove.some(id => matchesConversationId(c, id))
       )
+      idsToRemove.forEach(id => {
+        removeConversation(id)
+        window.dispatchEvent(
+          new CustomEvent('conversations:remove', {
+            detail: { conversationId: id },
+          })
+        )
+      })
     }
     emitConversationReload()
     router.replace('/conversations')

--- a/webui/src/views/ConversationsView.vue
+++ b/webui/src/views/ConversationsView.vue
@@ -306,6 +306,24 @@ function open(c) {
   })
 }
 
+function matchesConversationId(conversation = {}, targetId = '') {
+  const target = String(targetId || '')
+  if (!target) return false
+  const conversationId = String(
+    conversation?.id ||
+      conversation?.conversationId ||
+      conversation?.conversation_id ||
+      ''
+  )
+  const groupId = String(
+    conversation?.groupId ||
+      conversation?.group_id ||
+      conversation?.group?.id ||
+      ''
+  )
+  return target === conversationId || (groupId && target === groupId)
+}
+
 // Remove a conversation after user confirmation.
 async function warnDelete(c) {
   if (!c) return
@@ -378,8 +396,24 @@ const handleRemoveEvent = e => {
   const detail = e?.detail || {}
   const targetId = detail.conversationId ? String(detail.conversationId) : ''
   if (!targetId) return
-  convs.value = convs.value.filter(c => String(c.id) !== targetId)
-  removeConversation(targetId)
+  const matched = convs.value.filter(c => matchesConversationId(c, targetId))
+  convs.value = convs.value.filter(c => !matchesConversationId(c, targetId))
+  const idsToRemove = new Set([targetId])
+  matched.forEach(c => {
+    const candidateIds = [
+      c?.id,
+      c?.conversationId,
+      c?.conversation_id,
+      c?.groupId,
+      c?.group_id,
+      c?.group?.id,
+    ]
+    candidateIds.forEach(id => {
+      const key = String(id || '')
+      if (key) idsToRemove.add(key)
+    })
+  })
+  idsToRemove.forEach(id => removeConversation(id))
 }
 
 onMounted(async () => {


### PR DESCRIPTION
### Motivation
- Ensure that when a user leaves a group the conversation is fully removed from UI lists and the conversation store even when multiple identifier shapes are present (conversation id vs group id).
- Fix inconsistencies where a `conversations:remove` event containing one id did not clear all related conversation metadata and list entries.

### Description
- Added a `matchesConversationId` helper to `webui/src/views/ChatView.vue` and `webui/src/views/ConversationsView.vue` to robustly match a target id against possible conversation and group id fields.
- Updated `handleConversationRemove` in `ChatView.vue` and `handleRemoveEvent` in `ConversationsView.vue` to find matching list entries by `matchesConversationId`, remove them from the visible list, and collect all related ids before calling `removeConversation` for each stored identifier.
- Updated `onLeaveGroup` in `ChatView.vue` to collect relevant ids (`convId`, `groupId`, and multiple `currentConv` id variants), filter `convList` using `matchesConversationId`, call `removeConversation` for each id, and dispatch a `conversations:remove` event per removed id.
- Kept existing reload/refresh events (`emitConversationReload`, router navigation) while ensuring stored metadata is cleaned up alongside the visible list.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e00d9ae048331a22579e81765bd4d)