### PR TITLE
Remove conversation membership on leave group

### DIFF
--- a/service/database/group_database_methods.go
+++ b/service/database/group_database_methods.go
@@ -287,7 +287,13 @@ func (db *appdbimpl) SetGroupPhoto(groupID, photoUrl string) error {
 // LeaveGroup removes a user from a group.
 // Matches interface: LeaveGroup(groupID, userID string) error
 func (db *appdbimpl) LeaveGroup(groupID, userID string) error {
-	res, err := db.c.Exec(`
+	tx, err := db.c.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.Exec(`
                 DELETE FROM group_members WHERE group_id = ? AND user_id = ?
         `, groupID, userID)
 	if err != nil {
@@ -296,7 +302,16 @@ func (db *appdbimpl) LeaveGroup(groupID, userID string) error {
 	if n, _ := res.RowsAffected(); n == 0 {
 		return sql.ErrNoRows
 	}
-	return nil
+
+	if _, err := tx.Exec(`
+                DELETE FROM conversation_members
+                WHERE conversation_id = (SELECT conversation_id FROM groups WHERE id = ?)
+                  AND user_id = ?
+        `, groupID, userID); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 // IsGroupMember checks if a user is a member of a given group.


### PR DESCRIPTION
### Motivation
- Ensure that when a user leaves a group they are also removed from the associated conversation so the conversation no longer appears in the user’s conversation list, and make the operation atomic.

### Description
- Update `LeaveGroup` to run inside a DB transaction, delete the row from `group_members`, then delete the corresponding `conversation_members` row using `conversation_id = (SELECT conversation_id FROM groups WHERE id = ?)` and commit the transaction.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e03343e0c833194c34ded5e25cfc3)