### PR TITLE
Authorize message endpoints by conversation membership; add session plan & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WASA Text – Chat Application
 
-This repository hosts the **WASA Text – Chat Application**, built on top of the *Fantastic Coffee (decaffeinated)* starter shared in class. The goal is to provide a clean baseline for the Web and Software Architecture (WASA) homework while keeping production concerns out of scope. The original fully fledged reference remains in the "Fantastic Coffee" repository.
+This repository hosts the **WASA Text – Chat Application**, a WASA homework baseline built on top of the *Fantastic Coffee (decaffeinated)* starter shared in class. It is intended as a positive, educational full-stack chat project for practicing Web and Software Architecture concepts. The original fully fledged reference remains in the "Fantastic Coffee" repository.
 
 ## Overview
-WASA Text is a client-server chat application with a Go backend and a Vue.js frontend. It exposes REST APIs for chat workflows and ships a Web UI for interactive usage and manual testing.
+WASA Text is a client-server chat application with a Go backend and a Vue.js frontend. It exposes REST APIs for chat workflows and ships a Web UI for interactive usage, demos, and manual testing in a course setting.
 
 ## Tech stack & skills
 
@@ -50,6 +50,15 @@ The Web UI (`webui/`) is a lightweight client used to:
 - Quickly verify API behavior without external tools
 
 It is useful for demos, manual QA, and validating end-to-end API integration.
+
+## Known limitations
+
+This project is intentionally scoped as a course/full-stack homework baseline rather than a production-grade or research system. Current limitations include:
+
+- **Simplified authentication** — local development uses a lightweight authentication model suitable for coursework, not a hardened session system.
+- **Limited authorization hardening** — key chat flows include access checks, but the project has not been fully security-audited for production use.
+- **SQLite/dev deployment** — the default database and deployment flow are optimized for local development and grading, not high-availability operation.
+- **No formal research benchmark yet** — the project is useful for implementation practice and demos, but it does not include a validated research benchmark or comparative evaluation suite.
 
 ## Go vendoring
 
@@ -110,7 +119,7 @@ Launch the WebUI (in a new tab):
 yarn run dev
 ```
 
-## How to build for production / homework delivery
+## How to build for release / homework delivery
 
 ```bash
 ./open-node.sh

--- a/docs/auth-session-plan.md
+++ b/docs/auth-session-plan.md
@@ -1,0 +1,81 @@
+# Auth Session Plan
+
+## Current problem
+
+The API currently treats the bearer token as the user ID. This makes authentication easy to spoof, prevents server-side logout, and provides no secure way to expire or revoke credentials after login. Authorization checks can verify whether a user ID is allowed to access a resource, but they cannot prove the caller actually owns that identity.
+
+## Proposed `sessions` table schema
+
+Add a server-side sessions table and store only hashed tokens:
+
+```sql
+CREATE TABLE sessions (
+    id           TEXT PRIMARY KEY,
+    user_id      TEXT NOT NULL,
+    token_hash   TEXT NOT NULL UNIQUE,
+    created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at   TIMESTAMP NOT NULL,
+    revoked_at   TIMESTAMP,
+    last_seen_at TIMESTAMP,
+
+    FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_sessions_token_hash ON sessions(token_hash);
+CREATE INDEX idx_sessions_user_active ON sessions(user_id, expires_at, revoked_at);
+```
+
+## Login flow
+
+1. Validate the login request and resolve or create the user according to the existing login behavior.
+2. Generate a cryptographically random opaque token, for example 32 bytes from `crypto/rand` encoded with base64url.
+3. Hash the token and insert a new `sessions` row with `user_id`, `token_hash`, `created_at`, and `expires_at`.
+4. Return the raw token to the client once. Do not persist or log the raw token.
+5. Clients continue sending `Authorization: Bearer <token>` on API requests.
+
+## Request validation flow
+
+1. Parse the bearer token from the `Authorization` header.
+2. Reject missing or malformed tokens with `401 Unauthorized`.
+3. Hash the presented token using the same token hashing strategy.
+4. Look up a session by `token_hash`.
+5. Reject the request with `401 Unauthorized` if the session is missing, expired, or revoked.
+6. Load the session user and place the real `user_id` in `reqcontext.RequestContext`.
+7. Continue using existing resource authorization checks, such as conversation membership checks, with the session-derived user ID.
+8. Optionally update `last_seen_at` asynchronously or with throttling to avoid writing on every request.
+
+## Token hashing strategy
+
+- Use opaque random tokens rather than signed user-identifying tokens.
+- Store only a keyed hash of the token, such as HMAC-SHA-256 with a server secret, encoded as hex or base64url.
+- Compare token hashes using constant-time comparison when comparing in application code.
+- Keep the HMAC secret outside the database in environment/configuration.
+- Support secret rotation by adding a `hash_version` column if rotation is needed later.
+
+## Expiration and revocation
+
+- Set a finite `expires_at` for each session, for example 7 to 30 days depending on product requirements.
+- Treat sessions with non-null `revoked_at` as invalid immediately.
+- Add a logout endpoint that sets `revoked_at` for the current session.
+- Add an optional “logout all devices” operation that revokes all active sessions for a user.
+- Periodically delete old expired or revoked sessions after an audit-retention window.
+
+## Migration plan
+
+1. Add the `sessions` table in a database migration while keeping current token behavior unchanged.
+2. Update login to create sessions and return opaque session tokens.
+3. Update request context middleware to validate session tokens and set `ctx.UserID` from the session row.
+4. Temporarily support legacy `token == userID` only behind a development or migration flag, if needed.
+5. Update clients and tests to use login-issued session tokens.
+6. Remove the legacy fallback after clients have migrated.
+7. Verify authorization-sensitive endpoints still rely on `ctx.UserID`, not raw tokens.
+
+## Tests to add
+
+- Login creates a session row with the correct `user_id`, a future `expires_at`, and no stored raw token.
+- Valid session token populates `RequestContext.UserID`.
+- Missing, malformed, unknown, expired, and revoked tokens return `401 Unauthorized`.
+- Logout revokes only the current session.
+- Logout-all revokes all active sessions for the user.
+- Expired and revoked sessions cannot access protected endpoints.
+- Existing authorization tests still pass when `ctx.UserID` comes from a session instead of the raw bearer token.

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -48,7 +48,8 @@ func New(cfg Config) (*_router, error) {
 	// Fixes small path issues like duplicate slashes or case differences.
 	router.RedirectFixedPath = true
 
-	// We handle OPTIONS ourselves via middleware.
+	// CORS, including preflight handling, is centralized at the HTTP
+	// server entrypoint in cmd/webapi/cors.go instead of this API package.
 	router.HandleOPTIONS = false
 
 	r := &_router{

--- a/service/api/conversation_authorization.go
+++ b/service/api/conversation_authorization.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"errors"
+	"net/http"
 	"strings"
+
+	"github.com/GioiaZheng/Wasa_proj/service/models"
 )
 
 var (
@@ -35,4 +38,37 @@ func (rt *_router) requireConversationMember(userID, conversationID string) erro
 	}
 
 	return ErrConversationNotMember
+}
+
+// loadAuthorizedMessage loads a message by ID and verifies the current user is
+// a member of the message's conversation before the caller reads or mutates
+// message-scoped resources such as comments.
+func (rt *_router) loadAuthorizedMessage(w http.ResponseWriter, userID, messageID string) (models.Message, bool) {
+	m, err := rt.db.GetMessageByID(strings.TrimSpace(messageID))
+	if err != nil {
+		rt.sendError(w, http.StatusNotFound, "Message not found")
+		return models.Message{}, false
+	}
+	if !rt.authorizeMessageConversation(w, userID, m) {
+		return models.Message{}, false
+	}
+	return m, true
+}
+
+// authorizeMessageConversation verifies that the current user can access a
+// previously-loaded message through its conversation membership.
+func (rt *_router) authorizeMessageConversation(w http.ResponseWriter, userID string, m models.Message) bool {
+	if strings.TrimSpace(userID) == "" {
+		rt.sendError(w, http.StatusUnauthorized, "Unauthorized")
+		return false
+	}
+	if err := rt.requireConversationMember(userID, m.ConversationID); err != nil {
+		if errors.Is(err, ErrConversationNotMember) {
+			rt.sendError(w, http.StatusForbidden, "not your conversation")
+			return false
+		}
+		rt.sendError(w, http.StatusInternalServerError, "Failed to verify conversation membership")
+		return false
+	}
+	return true
 }

--- a/service/api/messages.go
+++ b/service/api/messages.go
@@ -337,7 +337,7 @@ func (rt *_router) getMessageByID(
 	w http.ResponseWriter,
 	_ *http.Request,
 	ps httprouter.Params,
-	_ reqcontext.RequestContext,
+	ctx reqcontext.RequestContext,
 ) {
 	id := strings.TrimSpace(ps.ByName("id"))
 	if id == "" {
@@ -347,6 +347,9 @@ func (rt *_router) getMessageByID(
 	m, err := rt.db.GetMessageByID(id)
 	if err != nil {
 		rt.sendError(w, http.StatusNotFound, "Message not found")
+		return
+	}
+	if !rt.authorizeMessageConversation(w, ctx.UserID, m) {
 		return
 	}
 	dto := toMessageDTO(m)
@@ -408,6 +411,18 @@ func (rt *_router) forwardMessage(
 		return
 	}
 
+	if _, ok := rt.loadAuthorizedMessage(w, userID, msgID); !ok {
+		return
+	}
+	if err := rt.requireConversationMember(userID, req.ConversationID); err != nil {
+		if errors.Is(err, ErrConversationNotMember) {
+			rt.sendError(w, http.StatusForbidden, "not your conversation")
+			return
+		}
+		rt.sendError(w, http.StatusInternalServerError, "Failed to verify conversation membership")
+		return
+	}
+
 	// Map to existing DB API: treat target conversation as a "group" sink.
 	// (If you have a real conversation->group lookup, add it here.)
 	if err := rt.db.ForwardMessage(userID, msgID /*toUserID*/, "" /*toGroupID*/, req.ConversationID); err != nil {
@@ -436,11 +451,14 @@ func (rt *_router) getMessageComments(
 	w http.ResponseWriter,
 	_ *http.Request,
 	ps httprouter.Params,
-	_ reqcontext.RequestContext,
+	ctx reqcontext.RequestContext,
 ) {
 	msgID := strings.TrimSpace(ps.ByName("id"))
 	if msgID == "" {
 		rt.sendError(w, http.StatusBadRequest, "Message ID is required")
+		return
+	}
+	if _, ok := rt.loadAuthorizedMessage(w, ctx.UserID, msgID); !ok {
 		return
 	}
 	rows, err := rt.db.GetMessageComments(msgID)
@@ -499,6 +517,10 @@ func (rt *_router) commentMessage(
 		return
 	}
 
+	if _, ok := rt.loadAuthorizedMessage(w, userID, msgID); !ok {
+		return
+	}
+
 	// Persist the comment using the normalized type and sanitized content.
 	if err := rt.db.CommentMessage(msgID, userID, req.Type, req.Content); err != nil {
 		rt.sendError(w, http.StatusInternalServerError, "Failed to add comment")
@@ -518,12 +540,20 @@ func (rt *_router) uncommentMessage(
 	ps httprouter.Params,
 	ctx reqcontext.RequestContext,
 ) {
+	userID := strings.TrimSpace(ctx.UserID)
+	if userID == "" {
+		rt.sendError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
 	msgID := strings.TrimSpace(ps.ByName("id"))
 	if msgID == "" {
 		rt.sendError(w, http.StatusBadRequest, "Message ID is required")
 		return
 	}
-	if err := rt.db.UncommentMessage(msgID, ctx.UserID); err != nil {
+	if _, ok := rt.loadAuthorizedMessage(w, userID, msgID); !ok {
+		return
+	}
+	if err := rt.db.UncommentMessage(msgID, userID); err != nil {
 		rt.sendError(w, http.StatusInternalServerError, "Failed to remove comment(s)")
 		return
 	}

--- a/service/api/messages_by_id_authorization_test.go
+++ b/service/api/messages_by_id_authorization_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	reqcontext "github.com/GioiaZheng/Wasa_proj/service/reqcontext"
+	"github.com/julienschmidt/httprouter"
+)
+
+func TestGetMessageByIDAllowsConversationMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+
+	req := httptest.NewRequest(http.MethodGet, "/messages/message-1", nil)
+	rr := httptest.NewRecorder()
+
+	rt.getMessageByID(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-1"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "message-1") {
+		t.Fatalf("response body does not contain seeded message: %s", rr.Body.String())
+	}
+}
+
+func TestGetMessageByIDDeniesConversationNonMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+
+	req := httptest.NewRequest(http.MethodGet, "/messages/message-1", nil)
+	rr := httptest.NewRecorder()
+
+	rt.getMessageByID(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "non-member"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+}
+
+func TestGetMessageCommentsAllowsConversationMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessageWithComment(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/messages/message-1/comment", nil)
+	rr := httptest.NewRecorder()
+
+	rt.getMessageComments(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-1"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "seeded comment") {
+		t.Fatalf("response body does not contain seeded comment: %s", rr.Body.String())
+	}
+}
+
+func TestGetMessageCommentsDeniesConversationNonMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessageWithComment(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/messages/message-1/comment", nil)
+	rr := httptest.NewRecorder()
+
+	rt.getMessageComments(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "non-member"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+}
+
+func TestCommentMessageAllowsConversationMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+	req := httptest.NewRequest(http.MethodPost, "/messages/message-1/comment", strings.NewReader(`{
+		"type":"text",
+		"content":"new comment"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	rt.commentMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-1"})
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+	assertCommentCount(t, rt, "message-1", 1)
+}
+
+func TestCommentMessageDeniesConversationNonMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+	req := httptest.NewRequest(http.MethodPost, "/messages/message-1/comment", strings.NewReader(`{
+		"type":"text",
+		"content":"new comment"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	rt.commentMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "non-member"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	assertCommentCount(t, rt, "message-1", 0)
+}
+
+func TestUncommentMessageAllowsConversationMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessageWithComment(t, rt)
+	req := httptest.NewRequest(http.MethodDelete, "/messages/message-1/comment", nil)
+	rr := httptest.NewRecorder()
+
+	rt.uncommentMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-1"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	assertCommentCount(t, rt, "message-1", 0)
+}
+
+func TestUncommentMessageDeniesConversationNonMember(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessageWithComment(t, rt)
+	req := httptest.NewRequest(http.MethodDelete, "/messages/message-1/comment", nil)
+	rr := httptest.NewRecorder()
+
+	rt.uncommentMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "non-member"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	assertCommentCount(t, rt, "message-1", 1)
+}
+
+func seedConversationMessageWithComment(t *testing.T, rt *_router) {
+	t.Helper()
+	seedConversationMessage(t, rt, "message-1", false)
+	if err := rt.db.CommentMessage("message-1", "member-1", "text", "seeded comment"); err != nil {
+		t.Fatalf("CommentMessage returned error: %v", err)
+	}
+}
+
+func assertCommentCount(t *testing.T, rt *_router, messageID string, want int) {
+	t.Helper()
+	comments, err := rt.db.GetMessageComments(messageID)
+	if err != nil {
+		t.Fatalf("GetMessageComments returned error: %v", err)
+	}
+	if len(comments) != want {
+		t.Fatalf("got %d comments, want %d", len(comments), want)
+	}
+}
+
+func messageIDParams(id string) httprouter.Params {
+	return httprouter.Params{{Key: "id", Value: id}}
+}

--- a/service/api/messages_forward_authorization_test.go
+++ b/service/api/messages_forward_authorization_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	reqcontext "github.com/GioiaZheng/Wasa_proj/service/reqcontext"
+)
+
+func TestForwardMessageAllowsAuthorizedSourceAndTarget(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+	targetID := createForwardTargetConversation(t, rt)
+	req := httptest.NewRequest(http.MethodPost, "/messages/message-1/forwards", strings.NewReader(`{
+		"conversationId":"`+targetID+`"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	rt.forwardMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-1"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	messages, err := rt.db.GetMessagesByConversation(targetID, "", "", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation returned error: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("got %d forwarded messages, want 1", len(messages))
+	}
+	if messages[0].SenderID != "member-1" {
+		t.Fatalf("SenderID = %q, want %q", messages[0].SenderID, "member-1")
+	}
+	if messages[0].Content != "seeded message" {
+		t.Fatalf("Content = %q, want %q", messages[0].Content, "seeded message")
+	}
+}
+
+func TestForwardMessageDeniesUnauthorizedSource(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+	targetID := createForwardTargetConversation(t, rt)
+	req := httptest.NewRequest(http.MethodPost, "/messages/message-1/forwards", strings.NewReader(`{
+		"conversationId":"`+targetID+`"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	rt.forwardMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "non-member"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	assertConversationMessageCount(t, rt, targetID, 0)
+}
+
+func TestForwardMessageDeniesUnauthorizedTarget(t *testing.T) {
+	rt := newConversationAuthorizationTestRouter(t)
+	seedConversationMessage(t, rt, "message-1", false)
+	targetID := createForwardTargetConversation(t, rt)
+	req := httptest.NewRequest(http.MethodPost, "/messages/message-1/forwards", strings.NewReader(`{
+		"conversationId":"`+targetID+`"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	rt.forwardMessage(rr, req, messageIDParams("message-1"), reqcontext.RequestContext{UserID: "member-2"})
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	assertConversationMessageCount(t, rt, targetID, 0)
+}
+
+func createForwardTargetConversation(t *testing.T, rt *_router) string {
+	t.Helper()
+	conv, err := rt.db.StartConversation(context.Background(), "member-1", []string{"non-member"}, "forward target")
+	if err != nil {
+		t.Fatalf("StartConversation returned error: %v", err)
+	}
+	return conv.ID
+}
+
+func assertConversationMessageCount(t *testing.T, rt *_router, conversationID string, want int) {
+	t.Helper()
+	messages, err := rt.db.GetMessagesByConversation(conversationID, "", "", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation returned error: %v", err)
+	}
+	if len(messages) != want {
+		t.Fatalf("got %d messages, want %d", len(messages), want)
+	}
+}


### PR DESCRIPTION
### Motivation

- Ensure message-scoped operations (read, comment, forward, delete/uncomment) validate that the caller is a member of the message's conversation to prevent unauthorized access.
- Centralize CORS handling at the HTTP server entrypoint rather than the API package to keep HTTP concerns separated from API logic.
- Provide a migration/design doc for secure server-side sessions to replace the current bearer-token-as-user-id approach.

### Description

- Added `docs/auth-session-plan.md` with a proposed `sessions` table schema, login/request validation flows, token hashing recommendations, expiry/revocation guidance, a migration plan, and tests to add.
- Introduced message-level authorization helpers in `service/api/conversation_authorization.go`: `loadAuthorizedMessage` and `authorizeMessageConversation`, and updated `requireConversationMember` to use the `models` package and `http` status helpers.
- Enforced conversation membership checks in message endpoints in `service/api/messages.go` including `getMessageByID`, `getMessageComments`, `forwardMessage`, `commentMessage`, and `uncommentMessage` by calling the new helpers before performing DB operations.
- Updated API router comments to indicate CORS/preflight handling is done in `cmd/webapi/cors.go` and left `router.HandleOPTIONS = false` in `service/api/api.go`.
- Updated `README.md` for clearer project description, added a `Known limitations` section, and adjusted wording for the release/build sections.
- Added unit tests covering authorization scenarios in `service/api/messages_by_id_authorization_test.go` and `service/api/messages_forward_authorization_test.go` to assert allowed and denied access for members and non-members.

### Testing

- Ran the API package unit tests with `go test ./service/api`, including the newly added authorization tests, and they passed.
- Ran the repository test suite with `go test ./...` to ensure no regressions in other packages, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e19fb90483329081276738589cd0)