### PR TITLE
Update axios to 1.17.0

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2",
-    "axios": "1.16.1",
+    "axios": "1.17.0",
     "bootstrap": "^5.3.0",
     "bootstrap-icons": "^1.11.0",
     "vue": "3.5.35",

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -661,15 +661,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.1":
-  version: 1.16.1
-  resolution: "axios@npm:1.16.1"
+"axios@npm:1.17.0":
+  version: 1.17.0
+  resolution: "axios@npm:1.17.0"
   dependencies:
     follow-redirects: ^1.16.0
     form-data: ^4.0.5
     https-proxy-agent: ^5.0.1
     proxy-from-env: ^2.1.0
-  checksum: 4b5daf07ed09e67d1884a98291023bd80a52854d705f6577eaa92ccc0c10b27df533e8c63d50cb3a321ce0efe4251760cdfb5eaa79c9d940d301914b3df9ddb5
+  checksum: 4bf030d85fde8720ebd112115223f162844505e4e44687749ba36e7b37241ef2e875fb8a5406be82097f4bc907362dc74f3ae94ea2c9cffca4fd2b2c37cafc5c
   languageName: node
   linkType: hard
 
@@ -1794,7 +1794,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2
     "@vitejs/plugin-vue": 5.2.4
-    axios: 1.16.1
+    axios: 1.17.0
     bootstrap: ^5.3.0
     bootstrap-icons: ^1.11.0
     vite: 6.4.3


### PR DESCRIPTION
## Summary
- Update the web UI axios dependency from 1.16.1 to 1.17.0.
- Refresh the web UI Yarn lockfile for the axios package checksum and dependency entry.
- Keep backend, SQLite, and web framework dependencies unchanged.

## Validation
- corepack yarn install --cwd webui --immutable
- corepack yarn --cwd webui run build-prod
- corepack yarn check:api-routes
- corepack yarn exec spectral lint doc/api.yaml --ruleset doc/spectral.yaml
- corepack yarn --cwd webui npm audit --severity high
- git diff --check
- python scripts/check_secrets.py
- trace scan for tool attribution markers in changed files

Local `go test ./...` and `go vet ./...` are blocked by the Windows go1.17 windows/386 environment and cgo/MinGW linker mismatch. GitHub Actions runs the Ubuntu Go 1.25.11 toolchain and is the authoritative validation for those checks.

Closes #135.
Supersedes #132.
