### PR TITLE
Add security policy and contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for your interest in this project. This guide covers local setup for
+the backend and Web UI, the checks that run in CI, and the conventions for
+branches, commits, and pull requests.
+
+## Setup
+
+The project has a Go backend (`cmd/webapi/`) and a Vue Web UI (`webui/`).
+Dependencies are vendored: Go modules under `vendor/`, and Yarn with an offline
+mirror under `.yarn/`.
+
+Backend:
+
+```bash
+go run ./cmd/webapi/
+```
+
+Web UI (separate terminal):
+
+```bash
+cd webui
+yarn install --immutable
+yarn run dev
+```
+
+The Web UI is served at `http://localhost:8080` and the API at
+`http://localhost:3000`. The full stack also runs under Docker:
+
+```bash
+docker compose up --build
+```
+
+See [TESTING.md](TESTING.md) for the recommended environment (the SQLite driver
+compiles with CGO, so a C compiler is required) and the exact tool versions.
+
+## Checks
+
+These run in CI and should pass locally before opening a pull request:
+
+```bash
+gofmt -l .            # must report no files
+go test ./...
+go vet ./...
+cd webui && yarn run build-prod
+yarn exec spectral lint doc/api.yaml --ruleset doc/spectral.yaml
+yarn check:api-routes  # API routes match the OpenAPI spec
+```
+
+## Branches
+
+Create a short-lived branch off `main` for each change and open a pull request
+back into `main`. Use a short, descriptive branch name (for example
+`fix/login-redirect` or `docs/security-policy`).
+
+## Commits
+
+- One logical change per commit.
+- Subject line in the imperative mood and capitalized, e.g.
+  `Add presence indicator to conversation list`.
+- Keep the backend, Web UI, and OpenAPI spec consistent in the same change —
+  if a route changes, update `doc/api.yaml` so `check:api-routes` stays green.
+
+## Pull requests
+
+- Open the pull request against `main`.
+- CI (Go format/test/vet, frontend build, OpenAPI lint, route coverage) must be
+  green before merge.
+- Reference the issue the change closes in the description.
+
+## Security
+
+Do not report vulnerabilities through public issues or pull requests; see
+[SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+This is an actively developed single-maintainer project. Security fixes are
+applied to the `main` branch and the most recent tagged release.
+
+| Version            | Supported |
+| ------------------ | --------- |
+| `main`             | yes       |
+| latest `v0.1.x`    | yes       |
+| older tags         | no        |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+Use GitHub's private vulnerability reporting: on the repository's **Security**
+tab, choose **Report a vulnerability**. This opens a private advisory visible
+only to the maintainer.
+
+If private reporting is unavailable, open a regular issue that only asks for a
+private contact channel — do not include any exploit details, affected
+endpoints, or reproduction steps in a public issue.
+
+When you report, please include where possible:
+
+- the affected component (backend service, Web UI, or OpenAPI surface),
+- a description of the impact,
+- steps to reproduce or a proof of concept.
+
+You can expect an acknowledgement within a few days. Once a fix is prepared,
+the advisory will be published with appropriate credit unless you prefer to
+remain anonymous.


### PR DESCRIPTION
Adds `SECURITY.md` (supported versions + private vulnerability reporting channel with a safe fallback) and `CONTRIBUTING.md` (backend + Web UI setup, the CI checks, and branch/commit/PR conventions).

Documentation only; no code or workflow behaviour change.

Closes #141.