### PR TITLE
[codex] Add lightweight maintenance templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/retrospective.md
+++ b/.github/ISSUE_TEMPLATE/retrospective.md
@@ -1,0 +1,23 @@
+---
+name: Retrospective / experiment note
+about: Capture what changed, what was learned, and what should happen next.
+title: "[review] "
+labels: ""
+assignees: ""
+---
+
+## Context
+
+<!-- What was the goal, experiment, bug, or decision? -->
+
+## What happened
+
+<!-- What changed, failed, worked, or surprised me? -->
+
+## What I learned
+
+<!-- Keep the useful lesson, trade-off, or design constraint. -->
+
+## Follow-up
+
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Keep this short and honest. Delete sections that do not apply. -->
+
+## Summary
+
+<!-- What changed and why? One logical change per pull request. -->
+
+## Evidence
+
+- [ ] Checks run:
+- [ ] Docs, screenshots, traces, or sample output updated if relevant:
+- [ ] Report or issue linked if relevant:
+
+## Review focus
+
+<!-- What would be most useful for someone to review? -->
+
+## Notes
+
+<!-- Trade-offs, follow-ups, release note, or out-of-scope items. -->
+
+Closes #

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,29 @@
+# Reports
+
+Use this folder for experiment reports, release notes, and retrospectives that need more context than a pull request description.
+
+Prefer one short file per experiment or milestone:
+
+- `YYYY-MM-DD-topic.md`
+
+## Template
+
+### Question
+
+What am I trying to learn, prove, or compare?
+
+### Setup
+
+Input, scenario, command, configuration, and any important assumptions.
+
+### Result
+
+Metrics, qualitative observations, or links to generated artifacts.
+
+### Interpretation
+
+What the result means, what changed my mind, and what remains uncertain.
+
+### Follow-up
+
+- [ ]


### PR DESCRIPTION
## Summary

Adds lightweight maintenance templates so future work can leave clearer PR descriptions, review notes, retrospectives, and short reports without adding a heavy process.

## Checks

- Documentation-only change.
- `git diff --cached --check` passed before commit.

## Notes

No runtime code changed. Report templates are intentionally short and optional, meant for experiments, release notes, or decisions that deserve more context than a PR.
