### PR TITLE
ci: fix Go vulnerability scan runtime

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,6 +2,7 @@ name: Go vulnerability scan
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -17,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
           cache: true
 
       - name: Run govulncheck


### PR DESCRIPTION
## What changed

- update the govulncheck job from Go 1.25.11 to Go 1.25.12
- run push-triggered scans only on `main`
- keep pull-request scanning for proposed changes

## Why

Go 1.25.11 is affected by GO-2026-5856 / CVE-2026-42505 in `crypto/tls`. The reachable TLS symbols reported by govulncheck are fixed in Go 1.25.12.

The workflow also listened to both every branch push and pull requests, so each PR branch update produced duplicate scan runs and notifications.

## Impact

No application code or module dependency changes. This updates the scanner runtime and removes duplicate branch-push runs while preserving PR and main-branch coverage.

## Validation

- workflow diff is limited to `.github/workflows/govulncheck.yml`
- GitHub Actions validation pending on this draft PR
