### PR TITLE
db: harden SQLite connection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ Automated repository checks include:
 These checks improve the development baseline but do not constitute a
 production security audit.
 
+## SQLite connection policy
+
+The API opens SQLite once at startup and shares a bounded `database/sql` pool
+across requests. The pool is limited to eight open and four idle connections;
+foreign-key enforcement, a five-second busy timeout, and WAL journaling are
+applied through driver options to every physical connection. Query result sets
+are closed before dependent follow-up queries, avoiding pool self-deadlocks.
+
+This is a correctness-oriented local deployment policy, not a published
+throughput claim. The repository does not currently report QPS or P99 latency
+without a reproducible benchmark and workload definition.
+
 ## Screenshots
 
 - [Login screen](docs/screenshots/chat-login-screen.svg)

--- a/cmd/webapi/main.go
+++ b/cmd/webapi/main.go
@@ -31,7 +31,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -44,7 +43,6 @@ import (
 	"github.com/GioiaZheng/Wasa_proj/service/database"
 	"github.com/GioiaZheng/Wasa_proj/service/globaltime"
 	"github.com/ardanlabs/conf"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 )
 
@@ -93,7 +91,7 @@ func run() error {
 
 	// Start Database
 	logger.Println("initializing database support")
-	dbconn, err := sql.Open("sqlite3", cfg.DB.Filename)
+	dbconn, err := database.OpenSQLite(cfg.DB.Filename)
 	if err != nil {
 		logger.WithError(err).Error("error opening SQLite DB")
 		return fmt.Errorf("opening SQLite: %w", err)

--- a/service/api/conversation_authorization_test.go
+++ b/service/api/conversation_authorization_test.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"database/sql"
 	"errors"
 	"io"
 	"path/filepath"
 	"testing"
 
 	"github.com/GioiaZheng/Wasa_proj/service/database"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +48,7 @@ func TestRequireConversationMemberDeniesEmptyConversationID(t *testing.T) {
 func newConversationAuthorizationTestRouter(t *testing.T) *_router {
 	t.Helper()
 
-	sqlDB, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "conversation-auth.db"))
+	sqlDB, err := database.OpenSQLite(filepath.Join(t.TempDir(), "conversation-auth.db"))
 	if err != nil {
 		t.Fatalf("open sqlite database: %v", err)
 	}

--- a/service/database/app_database.go
+++ b/service/database/app_database.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/GioiaZheng/Wasa_proj/service/models"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 // AppDatabase defines the database operations required by the API layer.
@@ -71,8 +70,10 @@ type appdbimpl struct {
 	c *sql.DB
 }
 
-// New wires a *sql.DB into the implementation, enabling PRAGMAs and ensuring
-// that the schema is present before returning a ready-to-use database handle.
+// New wires a *sql.DB into the implementation and ensures that the schema is
+// present before returning a ready-to-use database handle. Production callers
+// should obtain the pool through OpenSQLite so connection-local options apply
+// to every physical connection.
 func New(db *sql.DB) (*appdbimpl, error) {
 	// Verify connection
 	if err := db.Ping(); err != nil {

--- a/service/database/conversation_start.go
+++ b/service/database/conversation_start.go
@@ -161,6 +161,9 @@ func (db *appdbimpl) buildConversationFromID(cid string, requesterID string) (mo
 	if err := rows.Err(); err != nil {
 		return models.Conversation{}, err
 	}
+	if err := rows.Close(); err != nil {
+		return models.Conversation{}, err
+	}
 
 	// Determine conversation type and mirror peer details for private chats.
 	var isGroupConversation bool
@@ -298,7 +301,7 @@ func (db *appdbimpl) GetMyConversations(userID string) ([]models.Conversation, e
 	}
 	defer rows.Close()
 
-	result := []models.Conversation{}
+	conversationIDs := make([]string, 0)
 
 	for rows.Next() {
 		var cid string
@@ -308,16 +311,24 @@ func (db *appdbimpl) GetMyConversations(userID string) ([]models.Conversation, e
 			return nil, err
 		}
 
+		conversationIDs = append(conversationIDs, cid)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	result := make([]models.Conversation, 0, len(conversationIDs))
+	for _, cid := range conversationIDs {
 		conv, err := db.buildConversationFromID(cid, userID)
 		if err != nil {
 			return nil, err
 		}
 
 		result = append(result, conv)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, err
 	}
 
 	return result, nil

--- a/service/database/message_database_methods_test.go
+++ b/service/database/message_database_methods_test.go
@@ -1,17 +1,15 @@
 package database
 
 import (
-	"database/sql"
 	"path/filepath"
 	"testing"
 
 	"github.com/GioiaZheng/Wasa_proj/service/models"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestGetAllMessagesReturnsInsertedMessage(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "messages.db")
-	sqlDB, err := sql.Open("sqlite3", dbPath)
+	sqlDB, err := OpenSQLite(dbPath)
 	if err != nil {
 		t.Fatalf("open sqlite database: %v", err)
 	}

--- a/service/database/sqlite.go
+++ b/service/database/sqlite.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	sqliteMaxOpenConnections = 8
+	sqliteMaxIdleConnections = 4
+	sqliteBusyTimeoutMillis  = 5000
+)
+
+// OpenSQLite creates the shared SQLite connection pool used by the service.
+// Driver options are encoded in the DSN so they are applied to every physical
+// connection opened by database/sql, not only to the first connection.
+func OpenSQLite(filename string) (*sql.DB, error) {
+	dsn, err := buildSQLiteDSN(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open SQLite database: %w", err)
+	}
+
+	db.SetMaxOpenConns(sqliteMaxOpenConnections)
+	db.SetMaxIdleConns(sqliteMaxIdleConnections)
+
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("connect to SQLite database: %w", err)
+	}
+
+	return db, nil
+}
+
+func buildSQLiteDSN(filename string) (string, error) {
+	if strings.TrimSpace(filename) == "" {
+		return "", fmt.Errorf("SQLite filename is empty")
+	}
+
+	base := filename
+	rawQuery := ""
+	if queryStart := strings.IndexRune(filename, '?'); queryStart >= 0 {
+		base = filename[:queryStart]
+		rawQuery = filename[queryStart+1:]
+	}
+
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return "", fmt.Errorf("parse SQLite options: %w", err)
+	}
+
+	query.Set("_busy_timeout", fmt.Sprintf("%d", sqliteBusyTimeoutMillis))
+	query.Set("_foreign_keys", "on")
+	query.Set("_journal_mode", "WAL")
+
+	return base + "?" + query.Encode(), nil
+}

--- a/service/database/sqlite_test.go
+++ b/service/database/sqlite_test.go
@@ -1,0 +1,104 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenSQLiteConfiguresPoolAndEveryConnection(t *testing.T) {
+	db, err := OpenSQLite(filepath.Join(t.TempDir(), "pool.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer db.Close()
+
+	if got := db.Stats().MaxOpenConnections; got != sqliteMaxOpenConnections {
+		t.Fatalf("MaxOpenConnections = %d, want %d", got, sqliteMaxOpenConnections)
+	}
+
+	ctx := context.Background()
+	connections := make([]*sql.Conn, 0, 2)
+	for index := 0; index < 2; index++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("acquire connection: %v", err)
+		}
+		connections = append(connections, conn)
+	}
+	defer func() {
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+	}()
+
+	for index, conn := range connections {
+		var foreignKeys int
+		if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+			t.Fatalf("connection %d foreign_keys: %v", index, err)
+		}
+		if foreignKeys != 1 {
+			t.Errorf("connection %d foreign_keys = %d, want 1", index, foreignKeys)
+		}
+
+		var busyTimeout int
+		if err := conn.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+			t.Fatalf("connection %d busy_timeout: %v", index, err)
+		}
+		if busyTimeout != sqliteBusyTimeoutMillis {
+			t.Errorf("connection %d busy_timeout = %d, want %d", index, busyTimeout, sqliteBusyTimeoutMillis)
+		}
+	}
+}
+
+func TestOpenSQLiteEnforcesForeignKeys(t *testing.T) {
+	db, err := OpenSQLite(filepath.Join(t.TempDir(), "foreign-keys.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE parents (id INTEGER PRIMARY KEY);
+		CREATE TABLE children (
+			id INTEGER PRIMARY KEY,
+			parent_id INTEGER NOT NULL,
+			FOREIGN KEY(parent_id) REFERENCES parents(id)
+		);
+	`); err != nil {
+		t.Fatalf("create foreign-key fixture: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO children (id, parent_id) VALUES (1, 999)`); err == nil {
+		t.Fatal("insert with missing parent succeeded; foreign keys are not enforced")
+	}
+}
+
+func TestBuildSQLiteDSNOverridesConnectionOptions(t *testing.T) {
+	dsn, err := buildSQLiteDSN("test.db?_foreign_keys=off&_busy_timeout=1")
+	if err != nil {
+		t.Fatalf("buildSQLiteDSN: %v", err)
+	}
+
+	queryStart := strings.IndexRune(dsn, '?')
+	if queryStart < 0 {
+		t.Fatalf("DSN %q has no query options", dsn)
+	}
+	query, err := url.ParseQuery(dsn[queryStart+1:])
+	if err != nil {
+		t.Fatalf("parse DSN query: %v", err)
+	}
+
+	if got := query.Get("_foreign_keys"); got != "on" {
+		t.Errorf("_foreign_keys = %q, want on", got)
+	}
+	if got := query.Get("_busy_timeout"); got != "5000" {
+		t.Errorf("_busy_timeout = %q, want 5000", got)
+	}
+	if got := query.Get("_journal_mode"); got != "WAL" {
+		t.Errorf("_journal_mode = %q, want WAL", got)
+	}
+}


### PR DESCRIPTION
## What changed

- centralize SQLite startup in `database.OpenSQLite`
- bound the shared `database/sql` pool to 8 open and 4 idle connections
- apply foreign-key enforcement, a 5-second busy timeout, and WAL mode through driver DSN options so every physical connection receives them
- close participant and conversation result sets before dependent hydration queries
- move existing tests onto the production database opener
- add tests for pool limits, per-connection PRAGMAs, foreign-key enforcement, and DSN option overriding
- document the connection policy without making unsupported QPS or P99 claims

## Why

`sql.DB` is a connection pool. Executing `PRAGMA foreign_keys = ON` once during startup only configures the connection used for that statement; later pool connections may not inherit it. The conversation hydration paths also issued follow-up queries while result rows were still open, creating avoidable pool pressure and a self-deadlock risk under a tightly bounded pool.

## Validation

- `gofmt` completed for all changed Go files
- local compile-only check passed on Go 1.25.12
- GitHub Actions CI passed, including the new CGO-backed SQLite tests
- Secret scan passed
- Go vulnerability scan passed
- no API, authentication, schema, or dependency changes
